### PR TITLE
Special case the 'aliases' and 'virtual' pillar entries

### DIFF
--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -1,5 +1,5 @@
 {% set config = salt['pillar.get']('postfix', {}) -%}
-{% set processed_parameters = [] -%}
+{% set processed_parameters = ['aliases', 'virtual'] -%}
 {% macro set_parameter(parameter, default=None) -%}
 {% set value = config.get(parameter, default) -%}
 {% if value is not none -%}


### PR DESCRIPTION
They must not be added as non-standard parameters, they constitute
data for other files.

Fixes #6.