### PR TITLE
added map.jinja support

### DIFF
--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -1,14 +1,21 @@
+{% from "postfix/map.jinja" import postfix with context %}
+
 postfix:
-  pkg.installed: []
+  {% if postfix.packages is defined %}
+  pkg.installed:
+    - names:
+  {% for name in postfix.packages %}
+        - {{ name }}
+  {% endfor %}
+    - watch_in:
+      - service: postfix
+  {% endif %}
   service.running:
     - enable: True
     - require:
       - pkg: postfix
     - watch:
       - pkg: postfix
-
-postfix-policyd-spf-python:
-  pkg.installed: []
 
 # manage /etc/aliases if data found in pillar
 {% if 'aliases' in pillar.get('postfix', '') %}

--- a/postfix/map.jinja
+++ b/postfix/map.jinja
@@ -1,0 +1,10 @@
+{% set postfix = salt['grains.filter_by']({
+    'Debian': {
+        'packages': ['postfix', 'postfix-policyd-spf-python'],
+        'service': 'postfix',
+    },
+    'Gentoo': {
+        'packages': ['mail-mta/postfix'],
+        'service': 'postfix',
+    },
+}, merge=salt['pillar.get']('postfix:lookup')) %}


### PR DESCRIPTION
Hi,

I added a map.jinja as it is suggested by the formula best practice guide. This prepares the formula to be distro independent and to support more configurations.

I added the spf package to the packages variable in the map, but form my POV this should now be deprecated and added at will via pillar lookup stuff if needed.

Please merge.

And expect more to come ;-)

Kind regards
-Marc