### PR TITLE
Add option to let the module (not) manage the master.cf

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,23 +1,25 @@
 postfix:
-  smtpd_banner: $myhostname ESMTP $mail_name
-  biff: 'no'
+  manage_master_config: True
+  config:
+    smtpd_banner: $myhostname ESMTP $mail_name
+    biff: 'no'
 
-  append_dot_mydomain: 'no'
+    append_dot_mydomain: 'no'
 
-  readme_directory: 'no'
+    readme_directory: 'no'
 
-  smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
-  smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
-  smtpd_use_tls: 'yes'
-  smtpd_tls_session_cache_database: btree:${data_directory}/smtpd_scache
-  smtp_tls_session_cache_database: btree:${data_directory}/smtp_scache
+    smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
+    smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
+    smtpd_use_tls: 'yes'
+    smtpd_tls_session_cache_database: btree:${data_directory}/smtpd_scache
+    smtp_tls_session_cache_database: btree:${data_directory}/smtp_scache
 
-  myhostname: localhost
-  alias_maps: hash:/etc/aliases
-  alias_database: hash:/etc/aliases
-  mydestination: localhost, localhost.localdomain
-  relayhost: 
-  mynetworks: 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
-  mailbox_size_limit: 0
-  recipient_delimiter: +
-  inet_interfaces: all
+    myhostname: localhost
+    alias_maps: hash:/etc/aliases
+    alias_database: hash:/etc/aliases
+    mydestination: localhost, localhost.localdomain
+    relayhost: 
+    mynetworks: 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
+    mailbox_size_limit: 0
+    recipient_delimiter: +
+    inet_interfaces: all

--- a/postfix/config.sls
+++ b/postfix/config.sls
@@ -20,7 +20,7 @@ include:
     - watch_in:
       - service: postfix
     - template: jinja
-{% if salt['pillar.get']('postfix:manage_master_config', True) == True %}
+{% if salt['pillar.get']('postfix:manage_master_config', True) %}
 /etc/postfix/master.cf:
   file.managed:
     - source: salt://postfix/files/master.cf

--- a/postfix/config.sls
+++ b/postfix/config.sls
@@ -20,7 +20,7 @@ include:
     - watch_in:
       - service: postfix
     - template: jinja
-
+{% if salt['pillar.get']('postfix:manage_master_config', True) == True %}
 /etc/postfix/master.cf:
   file.managed:
     - source: salt://postfix/files/master.cf
@@ -32,4 +32,4 @@ include:
     - watch_in:
       - service: postfix
     - template: jinja
-
+{% endif %}

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -1,4 +1,4 @@
-{% set config = salt['pillar.get']('postfix', {}) -%}
+{% set config = salt['pillar.get']('postfix:config', {}) -%}
 {% set processed_parameters = ['aliases', 'virtual'] -%}
 {% macro set_parameter(parameter, default=None) -%}
 {% set value = config.get(parameter, default) -%}


### PR DESCRIPTION
Hi,

I had the need to provide my own master.cf. Since it was not worth the effort for me to template the whole master.cf file, I only added the option to choose if one wants to let the formula manage the master.cf.

Beware that the main.cf parameters are now in the postfix:config namespace. The pillar.example is updated as well, so that should be clear for everyone.

Greetings,
Jeroen