### PR TITLE
Misc enhancements

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -7,6 +7,10 @@ postfix:
     enabled: True
     location: inet:172.16.0.5:6379
 
+  policyd-spf:
+    enabled: True
+    time_limit: 7200s
+
   config:
     smtpd_banner: $myhostname ESMTP $mail_name
     biff: 'no'

--- a/pillar.example
+++ b/pillar.example
@@ -3,6 +3,10 @@ postfix:
   master_config:
     enable_submission: False
 
+  postgrey:
+    enabled: True
+    location: inet:172.16.0.5:6379
+
   config:
     smtpd_banner: $myhostname ESMTP $mail_name
     biff: 'no'

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -50,8 +50,7 @@
 {{ set_parameter('recipient_delimiter', '+') }}
 {{ set_parameter('inet_interfaces', 'all') }}
 {{ set_parameter('message_size_limit', '41943040') }}
-{{ set_parameter('policyd-spf_time_limit', '3600s') }}
-{{ set_parameter('smtpd_relay_restrictions', 'permit_mynetworks permit_sasl_authenticated defer_unauth_destination check_policy_service unix:private/policyd-spf') }}
+{{ set_parameter('smtpd_relay_restrictions', 'permit_mynetworks permit_sasl_authenticated defer_unauth_destination') }}
 
 
 {% if 'virtual' in pillar.get('postfix','') %}

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -57,7 +57,14 @@
 {{ set_parameter('recipient_delimiter', '+') }}
 {{ set_parameter('inet_interfaces', 'all') }}
 {{ set_parameter('message_size_limit', '41943040') }}
-{{ set_parameter('smtpd_relay_restrictions', ['permit_mynetworks', 'permit_sasl_authenticated', 'defer_unauth_destination']) }}
+
+{% set relay_restrictions = ['permit_mynetworks', 'permit_sasl_authenticated', 'defer_unauth_destination'] %}
+{% set policyd_spf = salt['pillar.get']('postfix:policyd-spf', {}) %}
+{% if policyd_spf.get('enabled', False) %}
+{% set relay_restrictions = relay_restrictions + ['check_policy_server unix:private/policyd-spf'] %}
+policy-spf_time_limit = {{ policyd_spf.get('time_limit', '3600s') }}
+{% endif %}
+{{ set_parameter('smtpd_relay_restrictions', relay_restrictions) }}
 
 {% set recipient_restrictions = ['permit_mynetworks', 'permit_sasl_authenticated', 'reject_unauth_destination'] %}
 {% set postgrey_config = salt['pillar.get']('postfix:postgrey', {}) %}

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -5,7 +5,14 @@
 {% macro set_parameter(parameter, default=None) -%}
 {% set value = config.get(parameter, default) -%}
 {% if value is not none -%}
+  {%- if value is number or value is string %}
 {{ parameter }} = {{ value }}
+  {%- elif value is iterable %}
+{{ parameter }} =
+    {%- for v in value %}
+       {{ v }},
+    {%- endfor %}
+  {%- endif %}
 {%- do processed_parameters.append(parameter) -%}
 {% endif -%}
 {% endmacro -%}
@@ -43,15 +50,14 @@
 {{ set_parameter('myhostname', grains['fqdn']) }}
 {{ set_parameter('alias_maps', 'hash:' ~ postfix.aliases) }}
 {{ set_parameter('alias_database', 'hash:' ~ postfix.aliases) }}
-{{ set_parameter('mydestination', grains['fqdn'] + ', localhost, localhost.localdomain, ' + grains['domain'] ) }}
+{{ set_parameter('mydestination', [grains['fqdn'], 'localhost', 'localhost.localdomain', grains['domain']]) }}
 {{ set_parameter('relayhost', '') }}
-{{ set_parameter('mynetworks', '127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128') }}
+{{ set_parameter('mynetworks', ['127.0.0.0/8', '[::ffff:127.0.0.0]/104', '[::1]/128']) }}
 {{ set_parameter('mailbox_size_limit', '0') }}
 {{ set_parameter('recipient_delimiter', '+') }}
 {{ set_parameter('inet_interfaces', 'all') }}
 {{ set_parameter('message_size_limit', '41943040') }}
-{{ set_parameter('smtpd_relay_restrictions', 'permit_mynetworks permit_sasl_authenticated defer_unauth_destination') }}
-
+{{ set_parameter('smtpd_relay_restrictions', ['permit_mynetworks', 'permit_sasl_authenticated', 'defer_unauth_destination']) }}
 
 {% if 'virtual' in pillar.get('postfix','') %}
 virtual_alias_maps = hash:/etc/postfix/virtual

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -59,6 +59,13 @@
 {{ set_parameter('message_size_limit', '41943040') }}
 {{ set_parameter('smtpd_relay_restrictions', ['permit_mynetworks', 'permit_sasl_authenticated', 'defer_unauth_destination']) }}
 
+{% set recipient_restrictions = ['permit_mynetworks', 'permit_sasl_authenticated', 'reject_unauth_destination'] %}
+{% set postgrey_config = salt['pillar.get']('postfix:postgrey', {}) %}
+{% if postgrey_config.get('enabled', False) %}
+{% set recipient_restrictions = recipient_restrictions + ['check_policy_service ' ~ postgrey_config.get('location', 'inet:127.0.0.1:10030')] %}
+{% endif %}
+{{ set_parameter('smtpd_recipient_restrictions', recipient_restrictions) }}
+
 {% if 'virtual' in pillar.get('postfix','') %}
 virtual_alias_maps = hash:/etc/postfix/virtual
 {% endif %}

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -1,3 +1,5 @@
+{% from "postfix/map.jinja" import postfix with context %}
+
 {% set config = salt['pillar.get']('postfix:config', {}) -%}
 {% set processed_parameters = ['aliases', 'virtual'] -%}
 {% macro set_parameter(parameter, default=None) -%}
@@ -39,8 +41,8 @@
 # information on enabling SSL in the smtp client.
 
 {{ set_parameter('myhostname', grains['fqdn']) }}
-{{ set_parameter('alias_maps', 'hash:/etc/aliases') }}
-{{ set_parameter('alias_database', 'hash:/etc/aliases') }}
+{{ set_parameter('alias_maps', 'hash:' ~ postfix.aliases) }}
+{{ set_parameter('alias_database', 'hash:' ~ postfix.aliases) }}
 {{ set_parameter('mydestination', grains['fqdn'] + ', localhost, localhost.localdomain, ' + grains['domain'] ) }}
 {{ set_parameter('relayhost', '') }}
 {{ set_parameter('mynetworks', '127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128') }}

--- a/postfix/files/master.cf
+++ b/postfix/files/master.cf
@@ -131,3 +131,7 @@ scache    unix  -       -       n       -       1       scache
 #mailman   unix  -       n       n       -       -       pipe
 #  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
 #  ${nexthop} ${user}
+{% if salt['pillar.get']('postfix:policyd-spf:enabled', False) %}
+policy-spf  unix  -       n       n       -       -       spawn
+  user=nobody argv=/usr/bin/policyd-spf
+{%- endif %}

--- a/postfix/files/master.cf
+++ b/postfix/files/master.cf
@@ -124,6 +124,3 @@ scalemail-backend unix	-	n	n	-	2	pipe
 mailman   unix  -       n       n       -       -       pipe
   flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
   ${nexthop} ${user}
-
-policyd-spf  unix  -       n       n       -       0       spawn
-  user=nobody argv=/usr/bin/policyd-spf /etc/postfix-policyd-spf-python/policyd-spf.conf

--- a/postfix/files/master.cf
+++ b/postfix/files/master.cf
@@ -8,15 +8,15 @@
 #
 # ==========================================================================
 # service type  private unpriv  chroot  wakeup  maxproc command + args
-#               (yes)   (yes)   (yes)   (never) (100)
+#               (yes)   (yes)   (no)    (never) (100)
 # ==========================================================================
-smtp      inet  n       -       -       -       -       smtpd
-#smtp      inet  n       -       -       -       1       postscreen
-#smtpd     pass  -       -       -       -       -       smtpd
-#dnsblog   unix  -       -       -       -       0       dnsblog
-#tlsproxy  unix  -       -       -       -       0       tlsproxy
+smtp      inet  n       -       n       -       -       smtpd
+#smtp      inet  n       -       n       -       1       postscreen
+#smtpd     pass  -       -       n       -       -       smtpd
+#dnsblog   unix  -       -       n       -       0       dnsblog
+#tlsproxy  unix  -       -       n       -       0       tlsproxy
 {% if master_config.get('enable_submission', False) %}
-submission inet n       -       -       -       -       smtpd
+submission inet n       -       n       -       -       smtpd
 #  -o syslog_name=postfix/submission
   -o smtpd_tls_security_level=encrypt
   -o smtpd_sasl_auth_enable=yes
@@ -28,7 +28,7 @@ submission inet n       -       -       -       -       smtpd
 #  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
 #  -o milter_macro_daemon_name=ORIGINATING
 {% endif %}
-#smtps     inet  n       -       -       -       -       smtpd
+#smtps     inet  n       -       n       -       -       smtpd
 #  -o syslog_name=postfix/smtps
 #  -o smtpd_tls_wrappermode=yes
 #  -o smtpd_sasl_auth_enable=yes
@@ -39,32 +39,32 @@ submission inet n       -       -       -       -       smtpd
 #  -o smtpd_recipient_restrictions=
 #  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
 #  -o milter_macro_daemon_name=ORIGINATING
-#628       inet  n       -       -       -       -       qmqpd
-pickup    unix  n       -       -       60      1       pickup
-cleanup   unix  n       -       -       -       0       cleanup
+#628       inet  n       -       n       -       -       qmqpd
+pickup    unix  n       -       n       60      1       pickup
+cleanup   unix  n       -       n       -       0       cleanup
 qmgr      unix  n       -       n       300     1       qmgr
 #qmgr     unix  n       -       n       300     1       oqmgr
-tlsmgr    unix  -       -       -       1000?   1       tlsmgr
-rewrite   unix  -       -       -       -       -       trivial-rewrite
-bounce    unix  -       -       -       -       0       bounce
-defer     unix  -       -       -       -       0       bounce
-trace     unix  -       -       -       -       0       bounce
-verify    unix  -       -       -       -       1       verify
-flush     unix  n       -       -       1000?   0       flush
+tlsmgr    unix  -       -       n       1000?   1       tlsmgr
+rewrite   unix  -       -       n       -       -       trivial-rewrite
+bounce    unix  -       -       n       -       0       bounce
+defer     unix  -       -       n       -       0       bounce
+trace     unix  -       -       n       -       0       bounce
+verify    unix  -       -       n       -       1       verify
+flush     unix  n       -       n       1000?   0       flush
 proxymap  unix  -       -       n       -       -       proxymap
 proxywrite unix -       -       n       -       1       proxymap
-smtp      unix  -       -       -       -       -       smtp
-relay     unix  -       -       -       -       -       smtp
+smtp      unix  -       -       n       -       -       smtp
+relay     unix  -       -       n       -       -       smtp
 #       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
-showq     unix  n       -       -       -       -       showq
-error     unix  -       -       -       -       -       error
-retry     unix  -       -       -       -       -       error
-discard   unix  -       -       -       -       -       discard
+showq     unix  n       -       n       -       -       showq
+error     unix  -       -       n       -       -       error
+retry     unix  -       -       n       -       -       error
+discard   unix  -       -       n       -       -       discard
 local     unix  -       n       n       -       -       local
 virtual   unix  -       n       n       -       -       virtual
-lmtp      unix  -       -       -       -       -       lmtp
-anvil     unix  -       -       -       -       1       anvil
-scache    unix  -       -       -       -       1       scache
+lmtp      unix  -       -       n       -       -       lmtp
+anvil     unix  -       -       n       -       1       anvil
+scache    unix  -       -       n       -       1       scache
 #
 # ====================================================================
 # Interfaces to non-Postfix software. Be sure to examine the manual
@@ -78,8 +78,8 @@ scache    unix  -       -       -       -       1       scache
 # maildrop. See the Postfix MAILDROP_README file for details.
 # Also specify in main.cf: maildrop_destination_recipient_limit=1
 #
-maildrop  unix  -       n       n       -       -       pipe
-  flags=DRhu user=vmail argv=/usr/bin/maildrop -d ${recipient}
+#maildrop  unix  -       n       n       -       -       pipe
+#  flags=DRhu user=vmail argv=/usr/local/bin/maildrop -d ${recipient}
 #
 # ====================================================================
 #
@@ -101,6 +101,7 @@ maildrop  unix  -       n       n       -       -       pipe
 #  user=cyrus argv=/cyrus/bin/deliver -e -r ${sender} -m ${extension} ${user}
 #
 # ====================================================================
+#
 # Old example of delivery via Cyrus.
 #
 #old-cyrus unix  -       n       n       -       -       pipe
@@ -110,17 +111,23 @@ maildrop  unix  -       n       n       -       -       pipe
 #
 # See the Postfix UUCP_README file for configuration details.
 #
-uucp      unix  -       n       n       -       -       pipe
-  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+#uucp      unix  -       n       n       -       -       pipe
+#  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+#
+# ====================================================================
 #
 # Other external delivery methods.
 #
-ifmail    unix  -       n       n       -       -       pipe
-  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
-bsmtp     unix  -       n       n       -       -       pipe
-  flags=Fq. user=bsmtp argv=/usr/lib/bsmtp/bsmtp -t$nexthop -f$sender $recipient
-scalemail-backend unix	-	n	n	-	2	pipe
-  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store ${nexthop} ${user} ${extension}
-mailman   unix  -       n       n       -       -       pipe
-  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
-  ${nexthop} ${user}
+#ifmail    unix  -       n       n       -       -       pipe
+#  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
+#
+#bsmtp     unix  -       n       n       -       -       pipe
+#  flags=Fq. user=bsmtp argv=/usr/local/sbin/bsmtp -f $sender $nexthop $recipient
+#
+#scalemail-backend unix -       n       n       -       2       pipe
+#  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store
+#  ${nexthop} ${user} ${extension}
+#
+#mailman   unix  -       n       n       -       -       pipe
+#  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
+#  ${nexthop} ${user}

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -19,7 +19,7 @@ postfix:
 
 # manage /etc/aliases if data found in pillar
 {% if 'aliases' in pillar.get('postfix', '') %}
-/etc/aliases:
+{{ postfix.aliases_file }}:
   file.managed:
     - source: salt://postfix/aliases
     - user: root
@@ -34,7 +34,7 @@ run-newaliases:
     - name: newaliases
     - cwd: /
     - watch:
-      - file: /etc/aliases
+      - file: {{ postfix.aliases_file }}
 {% endif %}
 
 # manage /etc/postfix/virtual if data found in pillar

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -1,15 +1,10 @@
 {% from "postfix/map.jinja" import postfix with context %}
 
 postfix:
-  {% if postfix.packages is defined %}
   pkg.installed:
-    - names:
-  {% for name in postfix.packages %}
-        - {{ name }}
-  {% endfor %}
+    - name: {{ postfix.package }}
     - watch_in:
       - service: postfix
-  {% endif %}
   service.running:
     - enable: True
     - require:

--- a/postfix/map.jinja
+++ b/postfix/map.jinja
@@ -3,20 +3,24 @@
         'packages': ['postfix', 'postfix-policyd-spf-python'],
         'postgrey_pkg': 'postgrey',
         'service': 'postfix',
+        'aliases': '/etc/aliases',
     },
     'Gentoo': {
         'packages': ['mail-mta/postfix'],
         'postgrey_pkg': 'postgrey',
         'service': 'postfix',
+        'aliases': '/etc/mail/aliases',
     },
     'RedHat': {
         'packages': ['postfix'],
         'postgrey_pkg': 'postgrey',
         'service': 'postfix',
+        'aliases': '/etc/aliases',
     },
     'Arch' : {
         'packages': ['postfix'],
         'postgrey_pkg': 'postgrey',
         'service': 'postfix',
+        'aliases': '/etc/aliases',
     },
 }, merge=salt['pillar.get']('postfix:lookup')) %}

--- a/postfix/map.jinja
+++ b/postfix/map.jinja
@@ -7,7 +7,7 @@
     },
     'Gentoo': {
         'packages': ['mail-mta/postfix'],
-        'postgrey_pkg': 'postgrey',
+        'postgrey_pkg': 'mail-filter/postgrey',
         'service': 'postfix',
         'aliases': '/etc/mail/aliases',
     },

--- a/postfix/map.jinja
+++ b/postfix/map.jinja
@@ -1,24 +1,24 @@
 {% set postfix = salt['grains.filter_by']({
     'Debian': {
-        'packages': ['postfix'],
+        'package': 'postfix',
         'postgrey_pkg': 'postgrey',
         'service': 'postfix',
         'aliases': '/etc/aliases',
     },
     'Gentoo': {
-        'packages': ['mail-mta/postfix'],
+        'package': 'mail-mta/postfix',
         'postgrey_pkg': 'mail-filter/postgrey',
         'service': 'postfix',
         'aliases': '/etc/mail/aliases',
     },
     'RedHat': {
-        'packages': ['postfix'],
+        'package': 'postfix',
         'postgrey_pkg': 'postgrey',
         'service': 'postfix',
         'aliases': '/etc/aliases',
     },
     'Arch' : {
-        'packages': ['postfix'],
+        'package': 'postfix',
         'postgrey_pkg': 'postgrey',
         'service': 'postfix',
         'aliases': '/etc/aliases',

--- a/postfix/map.jinja
+++ b/postfix/map.jinja
@@ -1,24 +1,28 @@
 {% set postfix = salt['grains.filter_by']({
     'Debian': {
         'package': 'postfix',
+        'policyd_spf_pkg': 'postfix-policyd-spf-python',
         'postgrey_pkg': 'postgrey',
         'service': 'postfix',
         'aliases': '/etc/aliases',
     },
     'Gentoo': {
         'package': 'mail-mta/postfix',
+        'policyd_spf_pkg': 'mail-filter/pypolicyd-spf',
         'postgrey_pkg': 'mail-filter/postgrey',
         'service': 'postfix',
         'aliases': '/etc/mail/aliases',
     },
     'RedHat': {
         'package': 'postfix',
+        'policyd_spf_pkg': 'pypolicyd-spf',
         'postgrey_pkg': 'postgrey',
         'service': 'postfix',
         'aliases': '/etc/aliases',
     },
     'Arch' : {
         'package': 'postfix',
+        'policyd_spf_pkg': 'python-postfix-policyd-spf',
         'postgrey_pkg': 'postgrey',
         'service': 'postfix',
         'aliases': '/etc/aliases',

--- a/postfix/map.jinja
+++ b/postfix/map.jinja
@@ -1,6 +1,6 @@
 {% set postfix = salt['grains.filter_by']({
     'Debian': {
-        'packages': ['postfix', 'postfix-policyd-spf-python'],
+        'packages': ['postfix'],
         'postgrey_pkg': 'postgrey',
         'service': 'postfix',
         'aliases': '/etc/aliases',

--- a/postfix/policyd-spf.sls
+++ b/postfix/policyd-spf.sls
@@ -1,0 +1,5 @@
+{% from "postfix/map.jinja" import postfix with context %}
+
+policyd_spf:
+  pkg.installed:
+    - name: {{ postfix.policyd_spf_pkg }}


### PR DESCRIPTION
I found this formula to change too many settings without proper controls so here is my contribution.

aliases can now be customized per distribution as it is a different path in Gentoo.

policyd-spf is now managed via pillar and has an independent sls file for installation. I looked up the name of the  package for all supported distributions though I can only test Gentoo. Also, I removed the optional configuration file passing in master.cf since I think the distribution should be responsible for having the package use the one that the distribution manages by default.

postgrey now enables relevant option in `smtpd_recipient_restrictions` and it can be changed via pillar.