### PR TITLE
Fix virtual handling - Add sender_canonical handling

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -3,6 +3,16 @@ postfix:
   master_config:
     enable_submission: False
 
+  virtual:
+    groupaliasexample: 
+     - someuser_1@example.com
+     - someuser_2@example.com
+    singlealiasexample: 'someuser_3@example.com'
+
+  sender_canonical:
+    root: 'servers@example.com'
+    nagios: 'alerts@example.com'
+
   postgrey:
     enabled: True
     location: inet:172.16.0.5:6379
@@ -34,3 +44,4 @@ postfix:
     mailbox_size_limit: 0
     recipient_delimiter: +
     inet_interfaces: all
+

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -1,6 +1,6 @@
 {%- from "postfix/map.jinja" import postfix with context -%}
 {%- set config = salt['pillar.get']('postfix:config', {}) -%}
-{% set processed_parameters = ['aliases_file', 'virtual'] %}
+{% set processed_parameters = ['aliases_file', 'virtual', 'sender_canonical'] %}
 {%- macro set_parameter(parameter, default=None) -%}
 {% set value = config.get(parameter, default) %}
 {%- if value is not none %}
@@ -101,6 +101,10 @@ policy-spf_time_limit = {{ policyd_spf.get('time_limit', '3600s') }}
 
 {% if 'virtual' in pillar.get('postfix','') %}
 virtual_alias_maps = hash:/etc/postfix/virtual
+{% endif %}
+
+{% if 'sender_canonical' in pillar.get('postfix','') %}
+sender_canonical_maps = hash:/etc/postfix/sender_canonical
 {% endif %}
 
 {# Accept arbitrary parameters -#}

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -51,3 +51,22 @@ run-postmap:
     - watch:
       - file: /etc/postfix/virtual
 {% endif %}
+
+# manage /etc/postfix/sender_canonical if data found in pillar
+{% if 'sender_canonical' in pillar.get('postfix', '') %}
+/etc/postfix/sender_canonical:
+  file.managed:
+    - source: salt://postfix/sender_canonical
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: postfix
+
+  cmd.wait:
+    - name: /usr/sbin/postmap /etc/postfix/sender_canonical
+    - cwd: /
+    - watch:
+      - file: /etc/postfix/sender_canonical
+{% endif %}

--- a/postfix/sender_canonical
+++ b/postfix/sender_canonical
@@ -1,0 +1,7 @@
+# Managed by config management
+{% set canonical = salt['pillar.get']('postfix:sender_canonical',{}) -%}
+{% if canonical is iterable -%}
+  {% for key,value in salt['pillar.get']('postfix:sender_canonical',{}).iteritems() -%}
+    {{ key }}  {{ value }}
+  {% endfor %}
+{% endif %}

--- a/postfix/virtual
+++ b/postfix/virtual
@@ -1,2 +1,17 @@
 # Managed by config management
-{{pillar['postfix']['virtual']}}
+{% set virtual = salt['pillar.get']('postfix:virtual',{}) -%}
+{# to have virtual file emptied, just set an empty key 'virtual' -#}
+{% if virtual is iterable -%}
+  {% for key, value in virtual.iteritems() -%}
+    {# Mutiple values available for single key in virtual alias maps - ie for dist groups -#}
+    {# We test if list was provided as value, and iterate if so -#}
+    {% if value is iterable and value is not string -%}
+      {% for item in value -%}
+{{key }}    {{ item }}
+      {% endfor -%}
+    {% else -%}
+      {# ..otherwise expect it to be just a string for the value -#}
+        {{ key }}   {{ value }}
+    {% endif -%}
+  {% endfor -%}
+{% endif -%}


### PR DESCRIPTION
The virtual alias handling does not work.  Output is the raw parsed yaml for the 'postfix:virtual' key.  ie:
```
# Managed by config management
{'info': ['someuser_1@example.com', 'someuser_2@example.com'], 'singlealiasexample': 'someuser_3@example.com'}
```

Add in handling to map it properly and handle lists as well for distribution groups
Example yaml snippet: 
```
  virtual:
    groupaliasexample: 
     - someuser_1@example.com
     - someuser_2@example.com
    singlealiasexample: 'someuser_3@example.com'
```

Also added in handling for sender_canonical
Example yaml snippet:
```
  sender_canonical:
    root: 'servers@example.com'
    nagios: 'alerts@example.com'
```

