### PR TITLE
enable smtp_sasl_password_maps: hash:/etc/postfix/sasl_password

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -9,6 +9,9 @@ postfix:
      - someuser_2@example.com
     singlealiasexample: 'someuser_3@example.com'
 
+  sasl_passwd:
+    smtp.example.com: 'somepassword'
+
   sender_canonical:
     root: 'servers@example.com'
     nagios: 'alerts@example.com'

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -1,6 +1,6 @@
 {%- from "postfix/map.jinja" import postfix with context -%}
 {%- set config = salt['pillar.get']('postfix:config', {}) -%}
-{% set processed_parameters = ['aliases_file', 'virtual', 'sender_canonical'] %}
+{% set processed_parameters = ['aliases_file', 'virtual', 'sasl_passwd', 'sender_canonical'] %}
 {%- macro set_parameter(parameter, default=None) -%}
 {% set value = config.get(parameter, default) %}
 {%- if value is not none %}
@@ -101,6 +101,10 @@ policy-spf_time_limit = {{ policyd_spf.get('time_limit', '3600s') }}
 
 {% if 'virtual' in pillar.get('postfix','') %}
 virtual_alias_maps = hash:/etc/postfix/virtual
+{% endif %}
+
+{% if 'sasl_passwd' in pillar.get('postfix','') %}
+smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
 {% endif %}
 
 {% if 'sender_canonical' in pillar.get('postfix','') %}

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -52,6 +52,25 @@ run-postmap:
       - file: /etc/postfix/virtual
 {% endif %}
 
+# manage /etc/postfix/sasl_passwd if data found in pillar
+{% if 'sasl_passwd' in pillar.get('postfix', '') %}
+/etc/postfix/sasl_passwd:
+  file.managed:
+    - source: salt://postfix/sasl_passwd
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: postfix
+
+  cmd.wait:
+    - name: /usr/sbin/postmap /etc/postfix/sasl_passwd
+    - cwd: /
+    - watch:
+      - file: /etc/postfix/sasl_passwd
+{% endif %}
+
 # manage /etc/postfix/sender_canonical if data found in pillar
 {% if 'sender_canonical' in pillar.get('postfix', '') %}
 /etc/postfix/sender_canonical:

--- a/postfix/sasl_passwd
+++ b/postfix/sasl_passwd
@@ -2,6 +2,6 @@
 {% set canonical = salt['pillar.get']('postfix:sasl_passwd',{}) -%}
 {% if canonical is iterable -%}
   {% for key,value in salt['pillar.get']('postfix:sasl_passwd',{}).iteritems() -%}
-    {{ key }}  {{ value }}
+{{ key }}  {{ value }}
   {% endfor %}
 {% endif %}

--- a/postfix/sasl_passwd
+++ b/postfix/sasl_passwd
@@ -1,0 +1,2 @@
+# Managed by config management
+{{pillar['postfix']['sasl_passwd']}}

--- a/postfix/sasl_passwd
+++ b/postfix/sasl_passwd
@@ -1,2 +1,7 @@
 # Managed by config management
-{{pillar['postfix']['sasl_passwd']}}
+{% set canonical = salt['pillar.get']('postfix:sasl_passwd',{}) -%}
+{% if canonical is iterable -%}
+  {% for key,value in salt['pillar.get']('postfix:sasl_passwd',{}).iteritems() -%}
+    {{ key }}  {{ value }}
+  {% endfor %}
+{% endif %}

--- a/postfix/sasl_passwd
+++ b/postfix/sasl_passwd
@@ -1,7 +1,7 @@
 # Managed by config management
 {% set canonical = salt['pillar.get']('postfix:sasl_passwd',{}) -%}
 {% if canonical is iterable -%}
-  {% for key,value in salt['pillar.get']('postfix:sasl_passwd',{}).iteritems() -%}
+{% for key,value in salt['pillar.get']('postfix:sasl_passwd',{}).iteritems() -%}
 {{ key }}  {{ value }}
-  {% endfor %}
+{% endfor %}
 {% endif %}


### PR DESCRIPTION
This is my first pull request for a salt-formula. It is heavily plagiarized from the sender_canonical handling.