### PR TITLE
Fixing file mode bug in init.sls

### DIFF
--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -20,7 +20,7 @@ postmap_{{ filename }}:
     - source: salt://postfix/{{ filename }}
     - user: root
     - group: root
-    - mode: 0644
+    - mode: 644
     - template: jinja
     - require:
       - pkg: postfix


### PR DESCRIPTION
There is a bug in the init.sls file that specifies 0644 and not 644. I could have quoted the mode instead however I chose 644 to match the other file mode.

Further reading

https://docs.saltstack.com/en/latest/topics/troubleshooting/yaml_idiosyncrasies.html#integers-are-parsed-as-integers