### PR TITLE
WIP: Generic map handling

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -55,6 +55,8 @@ postfix:
     smtp_tls_cert_file: /etc/postfix/ssl/example.com-relay-client-cert.crt
     smtp_tls_key_file: /etc/postfix/ssl/example.com-relay-client-cert.key
 
+    smtp_sasl_password_maps: hash:/etc/postfix/sasl_passwd
+
   certificates:
     server-cert:
       public_cert: |
@@ -81,3 +83,7 @@ postfix:
         -----BEGIN RSA PRIVATE KEY-----
         (Your Private key)
         -----END RSA PRIVATE KEY-----
+
+  mapping:
+    smtp_sasl_password_maps:
+      - "my-isp.tld:587": myaccount:supersecretpassword

--- a/postfix/files/mapping
+++ b/postfix/files/mapping
@@ -1,7 +1,7 @@
 # Managed by config management
-{% set virtual = salt['pillar.get']('postfix:virtual',{}) -%}
+{% set virtual = data -%}
 {# to have virtual file emptied, just set an empty key 'virtual' -#}
-{% if virtual is iterable -%}
+{% if virtual is mapping -%}
   {% for key, value in virtual.iteritems() -%}
     {# Mutiple values available for single key in virtual alias maps - ie for dist groups -#}
     {# We test if list was provided as value, and iterate if so -#}
@@ -14,4 +14,8 @@
 {{ key }}   {{ value }}
     {% endif -%}
   {% endfor -%}
+{% else %}
+{%- for item in virtual %}
+{{ item.keys()[0] }}	{{ item.values()[0] }}
+{%- endfor %}
 {% endif -%}

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -12,25 +12,6 @@ postfix:
     - watch:
       - pkg: postfix
 
-{%- macro postmap_file(filename, mode=644) %}
-{%- set file_path = '/etc/postfix/' ~ filename %}
-postmap_{{ filename }}:
-  file.managed:
-    - name: {{ file_path }}
-    - source: salt://postfix/{{ filename }}
-    - user: root
-    - group: root
-    - mode: {{ mode }}
-    - template: jinja
-    - require:
-      - pkg: postfix
-  cmd.wait:
-    - name: /usr/sbin/postmap {{ file_path }}
-    - cwd: /
-    - watch:
-      - file: {{ file_path }}
-{%- endmacro %}
-
 # manage /etc/aliases if data found in pillar
 {% if 'aliases' in pillar.get('postfix', '') %}
 {{ postfix.aliases_file }}:
@@ -51,17 +32,37 @@ run-newaliases:
       - file: {{ postfix.aliases_file }}
 {% endif %}
 
-# manage /etc/postfix/virtual if data found in pillar
-{% if 'virtual' in pillar.get('postfix', '') %}
-{{ postmap_file('virtual') }}
-{% endif %}
-
-# manage /etc/postfix/sasl_passwd if data found in pillar
-{% if 'sasl_passwd' in pillar.get('postfix', '') %}
-{{ postmap_file('sasl_passwd', 600) }}
-{% endif %}
-
-# manage /etc/postfix/sender_canonical if data found in pillar
-{% if 'sender_canonical' in pillar.get('postfix', '') %}
-{{ postmap_file('sender_canonical') }}
-{% endif %}
+# manage various mappings
+{% for mapping, data in salt['pillar.get']('postfix:mapping', {}).items() %}
+  {%- set need_postmap = False %}
+  {%- set file_path = salt['pillar.get']('postfix:config:' ~ mapping) %}
+  {%- if ':' in file_path %}
+    {%- set file_path = file_path.split(':')[1] %}
+    {%- set need_postmap = True %}
+  {%- endif %}
+postfix_{{ mapping }}:
+  file.managed:
+    - name: {{ file_path }}
+    - source: salt://postfix/files/mapping
+    - user: root
+    - group: root
+    {%- if mapping == 'smtp_sasl_password_maps' %}
+    - mode: 600
+    {%- else %}
+    - mode: 644
+    {%- endif %}
+    - template: jinja
+    - context:
+        data: {{ data|json() }}
+    - require:
+      - pkg: postfix
+  {%- if need_postmap %}
+  cmd.wait:
+    - name: /usr/sbin/postmap {{ file_path }}
+    - cwd: /
+    - watch:
+      - file: {{ file_path }}
+    - watch_in:
+      - service: postfix
+  {%- endif %}
+{% endfor %}

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -12,7 +12,7 @@ postfix:
     - watch:
       - pkg: postfix
 
-{%- macro postmap_file(filename) %}
+{%- macro postmap_file(filename, mode=644) %}
 {%- set file_path = '/etc/postfix/' ~ filename %}
 postmap_{{ filename }}:
   file.managed:
@@ -20,7 +20,7 @@ postmap_{{ filename }}:
     - source: salt://postfix/{{ filename }}
     - user: root
     - group: root
-    - mode: 644
+    - mode: {{ mode }}
     - template: jinja
     - require:
       - pkg: postfix
@@ -58,7 +58,7 @@ run-newaliases:
 
 # manage /etc/postfix/sasl_passwd if data found in pillar
 {% if 'sasl_passwd' in pillar.get('postfix', '') %}
-{{ postmap_file('sasl_passwd') }}
+{{ postmap_file('sasl_passwd', 600) }}
 {% endif %}
 
 # manage /etc/postfix/sender_canonical if data found in pillar

--- a/postfix/sasl_passwd
+++ b/postfix/sasl_passwd
@@ -1,7 +1,0 @@
-# Managed by config management
-{% set canonical = salt['pillar.get']('postfix:sasl_passwd',{}) -%}
-{% if canonical is iterable -%}
-{% for key,value in salt['pillar.get']('postfix:sasl_passwd',{}).iteritems() -%}
-{{ key }}  {{ value }}
-{% endfor %}
-{% endif %}

--- a/postfix/sender_canonical
+++ b/postfix/sender_canonical
@@ -1,7 +1,0 @@
-# Managed by config management
-{% set canonical = salt['pillar.get']('postfix:sender_canonical',{}) -%}
-{% if canonical is iterable -%}
-  {% for key,value in salt['pillar.get']('postfix:sender_canonical',{}).iteritems() -%}
-    {{ key }}  {{ value }}
-  {% endfor %}
-{% endif %}


### PR DESCRIPTION
After writing `postmap_macro`, it occurend to me that it still did not satisfy a more complex setup requiring address rewriting, etc. I happen to have just setup a relay that needed `smtp_generic_maps` so I took the opportunity to try to tackle this issue.

Please do not merge this work as is.

The idea is to move `*_maps` to `postfix:mapping` section and write data properly formatted to file pointed to by the configuration in `postfix:config`. This removes restriction on filename at the cost of being a tad more verbose.

If this seems like a good approach, I will cleanup the commit, especially the mapping template file.

Also, it seems to me that aliases could benefit from the same treatment so more work is required.