### PR TITLE
Make postconf/newaliases respect file type

### DIFF
--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -12,6 +12,9 @@ postfix:
     - watch:
       - pkg: postfix
 
+{# Used for newaliases, postalias and postconf #}
+{%- set default_database_type = salt['pillar.get']('postfix:config:default_database_type', 'hash') %}
+
 # manage /etc/aliases if data found in pillar
 {% if 'aliases' in pillar.get('postfix', '') %}
 {{ postfix.aliases_file }}:
@@ -38,9 +41,11 @@ run-newaliases:
   {%- set file_path = salt['pillar.get']('postfix:config:' ~ mapping) %}
   {%- if ':' in file_path %}
     {%- set file_type, file_path = file_path.split(':') %}
-    {%- if file_type in ("btree", "cdb", "dbm", "hash", "sdbm") %}
-      {%- set need_postmap = True %}
-    {%- endif %}
+  {%- else %}
+    {%- set file_type = default_database_type %}
+  {%- endif %}
+  {%- if file_type in ("btree", "cdb", "dbm", "hash", "sdbm") %}
+    {%- set need_postmap = True %}
   {%- endif %}
 postfix_{{ mapping }}:
   file.managed:

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -37,8 +37,10 @@ run-newaliases:
   {%- set need_postmap = False %}
   {%- set file_path = salt['pillar.get']('postfix:config:' ~ mapping) %}
   {%- if ':' in file_path %}
-    {%- set file_path = file_path.split(':')[1] %}
-    {%- set need_postmap = True %}
+    {%- set file_type, file_path = file_path.split(':') %}
+    {%- if file_type in ("btree", "cdb", "dbm", "hash", "sdbm") %}
+      {%- set need_postmap = True %}
+    {%- endif %}
   {%- endif %}
 postfix_{{ mapping }}:
   file.managed:


### PR DESCRIPTION
As reported in issue #50, formula needs to respect the file type in order to run postmap/newaliases only when appropriate.

Added support for `default_database_type` while at it. The default value is just the one I found to be the most common but this could be customized via `map.jinja` or determined automatically by calling `postconf -d` however I decided to discard that until someone requests it eventually.

Things that could be done to enhance alias database handling is override `map.jinja` `aliases_file` with pillar provided `alias_database` setting and support running `postalias` on `alias_maps` if it makes any difference wrt `postmap`.