### PR TITLE
en-/disable domain in mydestination

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -2,6 +2,8 @@ postfix:
   manage_master_config: True
   master_config:
     enable_submission: False
+  main_config:
+    include_domain_in_mydestination: True
 
   enable_service: True
 

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -74,7 +74,11 @@
 {{ set_parameter('myhostname', grains['fqdn']) }}
 {{ set_parameter('alias_maps', 'hash:' ~ postfix.aliases_file) }}
 {{ set_parameter('alias_database', 'hash:' ~ postfix.aliases_file) }}
+{%- if salt['pillar.get']('postfix:main_config:include_domain_in_mydestination', True) %}
 {{ set_parameter('mydestination', [grains['fqdn'], 'localhost', 'localhost.localdomain', grains['domain']]) }}
+{%- else %}
+{{ set_parameter('mydestination', [grains['fqdn'], 'localhost', 'localhost.localdomain']) }}
+{%- endif %}
 {{ set_parameter('relayhost', '') }}
 {{ set_parameter('mynetworks', ['127.0.0.0/8', '[::ffff:127.0.0.0]/104', '[::1]/128']) }}
 {{ set_parameter('mailbox_size_limit', '0') }}


### PR DESCRIPTION
If I setup a server with hostname subdomain.example.com example.com is configured in postfix' mydestination so that every mail addressed to someone@example.com is sent to local postfix.