### PR TITLE
Use join() for iterable values in main.cf

### DIFF
--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -8,9 +8,7 @@
 {{ parameter }} = {{ value }}
   {%- elif value is iterable -%}
 {{ parameter }} =
-    {%- for v in value %}
-       {{ v }},
-    {%- endfor %}
+       {{ value | join(', ')}}
   {%- endif -%}
 {%- do processed_parameters.append(parameter) %}
 {%- endif %}


### PR DESCRIPTION
Before this PR, lists ended up generating things like
```
attribute = 
  value1,
  value2,
  ...
  valueN,
```
(note the last ",")

This PR [reproduces the behaviour of mappings](https://github.com/saltstack-formulas/postfix-formula/blob/master/postfix/files/mapping.j2#L6), rendering now
```
attribute = value1, value2, ..., valueN
```