### PR TITLE
Add a mysql query to 'virtual' files

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -94,6 +94,20 @@ postfix:
     hosts: DB_HOST
     dbname: postfix_db
 
+  mysql:
+    virtual_mailbox_domains:
+      table: virtual_domains
+      select_field: 1
+      where_field: name
+    virtual_alias_maps:
+      table: virtual_aliases
+      select_field: destination
+      where_field: email
+    virtual_mailbox_maps:
+      table: virtual_users
+      select_field: 1
+      where_field: email
+
   certificates:
     server-cert:
       public_cert: |

--- a/postfix/files/virtual_alias_maps.cf
+++ b/postfix/files/virtual_alias_maps.cf
@@ -1,3 +1,10 @@
+{%- if 'mysql' in salt['pillar.get']('postfix:config:virtual_alias_maps', '') %}
+{%- set config = salt['pillar.get']('postfix:mysql:virtual_alias_maps', {}) -%}
+{%- for key,value in salt['pillar.get']('postfix:vmail').items() %}
+{{ key }} = {{ value }}
+{%- endfor %}
+query = SELECT {{ config.select_field|default('destination') }} FROM {{ config.table|default('virtual_aliases') }} WHERE {{ config.where_field|default('email') }}='%s'
+{%- else %}
 {% set config = salt['pillar.get']('postfix:vmail', {}) -%}
 {% macro set_parameter(parameter, default=None) -%}
 {% set value = config.get(parameter, default) -%}
@@ -14,4 +21,4 @@
 {{ set_parameter('table', 'alias') }}
 {{ set_parameter('select_field', 'goto') }}
 {{ set_parameter('where_field', 'address') }}
-
+{%- endif %}

--- a/postfix/files/virtual_mailbox_domains.cf
+++ b/postfix/files/virtual_mailbox_domains.cf
@@ -1,3 +1,10 @@
+{%- if 'mysql' in salt['pillar.get']('postfix:config:virtual_mailbox_domains', '') %}
+{%- set config = salt['pillar.get']('postfix:mysql:virtual_mailbox_domains', {}) -%}
+{%- for key,value in salt['pillar.get']('postfix:vmail').items() %}
+{{ key }} = {{ value }}
+{%- endfor %}
+query = SELECT {{ config.select_field|default('1') }} FROM {{ config.table|default('virtual_domains') }} WHERE {{ config.where_field|default('name') }}='%s'
+{%- else %}
 {% set config = salt['pillar.get']('postfix:vmail', {}) -%}
 {% macro set_parameter(parameter, default=None) -%}
 {% set value = config.get(parameter, default) -%}
@@ -14,4 +21,4 @@
 {{ set_parameter('table', 'domain') }}
 {{ set_parameter('select_field', 'domain') }}
 {{ set_parameter('where_field', 'domain') }}
-
+{%- endif %}

--- a/postfix/files/virtual_mailbox_maps.cf
+++ b/postfix/files/virtual_mailbox_maps.cf
@@ -1,3 +1,10 @@
+{%- if 'mysql' in salt['pillar.get']('postfix:config:virtual_mailbox_maps', '') %}
+{%- set config = salt['pillar.get']('postfix:mysql:virtual_mailbox_maps', {}) -%}
+{%- for key,value in salt['pillar.get']('postfix:vmail').items() %}
+{{ key }} = {{ value }}
+{%- endfor %}
+query = SELECT {{ config.select_field|default('1') }} FROM {{ config.table|default('virtual_users') }} WHERE {{ config.where_field|default('email') }}='%s'
+{%- else %}
 {% set config = salt['pillar.get']('postfix:vmail', {}) -%}
 {% macro set_parameter(parameter, default=None) -%}
 {% set value = config.get(parameter, default) -%}
@@ -14,4 +21,4 @@
 {{ set_parameter('table', 'mailbox') }}
 {{ set_parameter('select_field', 'maildir') }}
 {{ set_parameter('where_field', 'username') }}
-
+{%- endif %}


### PR DESCRIPTION
Add a mysql query to virtual_mailbox_domains, virtual_alias_maps  virtual_mailbox_maps if mysql is declared in main.cf within these options.
If no pillar is defined, it uses default values.

If no mysql is used, nothing is changed.