### PR TITLE
Use alias states for managing mail aliases.

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -94,6 +94,21 @@ postfix:
     hosts: DB_HOST
     dbname: postfix_db
 
+  aliases:
+    # manage single aliases
+    # this uses the aliases file defined in the minion config, /etc/aliases by default
+    use_file: false
+    present:
+      root: info@example.com
+    absent:
+      - root
+
+    # manage entire aliases file
+    use_file: true
+    content: |
+      # Forward all local *nix users mail to our admins (via greedy regexp)
+      /.+/    admins@example.com
+
   certificates:
     server-cert:
       public_cert: |

--- a/postfix/aliases
+++ b/postfix/aliases
@@ -1,3 +1,3 @@
 # Managed by config management
 # See man 5 aliases for format
-{{pillar['postfix']['aliases']}}
+{{pillar['postfix']['aliases']['content']}}


### PR DESCRIPTION
Using the alias states makes it easier to add/remove single entries rather than having to migrate the entire file into a pillar config.