### PR TITLE
Restructured to Add Support for FreeBSD

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -36,6 +36,9 @@ postfix:
 
     # Alias
     alias_maps: hash:/etc/aliases
+    # This is the list of files for the newaliases
+    # cmd to process (see postconf(5) for details).
+    # Only local hash/btree/dbm files:
     alias_database: hash:/etc/aliases
 
     # Virtual users

--- a/postfix/aliases
+++ b/postfix/aliases
@@ -1,3 +1,0 @@
-# Managed by config management
-# See man 5 aliases for format
-{{pillar['postfix']['aliases']['content']}}

--- a/postfix/defaults.yaml
+++ b/postfix/defaults.yaml
@@ -7,4 +7,6 @@ postfix:
     package: postfix
     postsrsd_pkg: postsrsd
     postgrey_pkg: postgrey
+    root_grp: root
     service: postfix
+    xbin_prefix: /usr

--- a/postfix/defaults.yaml
+++ b/postfix/defaults.yaml
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+postfix:
+    aliases_file: /etc/aliases
+    config_path: /etc/postfix
+    package: postfix
+    postsrsd_pkg: postsrsd
+    postgrey_pkg: postgrey
+    service: postfix

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -97,17 +97,22 @@ policy-spf_time_limit = {{ policyd_spf.get('time_limit', '3600s') }}
 {%- endif %}
 {{ set_parameter('smtpd_recipient_restrictions', recipient_restrictions) }}
 
-{% if 'virtual' in pillar.get('postfix','') %}
-virtual_alias_maps = hash:/etc/postfix/virtual
-{% endif %}
+{# From init.sls #}
+{%- set default_database_type = salt['pillar.get']('postfix:config:default_database_type', 'hash') %}
 
-{% if 'sasl_passwd' in pillar.get('postfix','') %}
-smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
-{% endif %}
+{%- for mapping, data in salt['pillar.get']('postfix:mapping', {}).items() %}
+  {%- set file_path = salt['pillar.get']('postfix:config:' ~ mapping) %}
+  {%- if ':' in file_path %}
+    {%- set file_type, file_path = file_path.split(':') %}
+  {%- else %}
+    {%- set file_type = default_database_type %}
+  {%- endif %}
+  {%- if not file_path.startswith('/') %}
+    {%- set file_path = postfix.config_path ~ '/' ~ file_path %}
+  {%- endif %}
 
-{% if 'sender_canonical' in pillar.get('postfix','') %}
-sender_canonical_maps = hash:/etc/postfix/sender_canonical
-{% endif %}
+{{ mapping }} = {{ file_type }}:{{ file_path }}
+{% endfor %}
 
 {# Accept arbitrary parameters -#}
 {% for parameter in config -%}

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -1,7 +1,7 @@
 {%- from "postfix/map.jinja" import postfix with context -%}
 {%- set config = salt['pillar.get']('postfix:config', {}) -%}
+{#- TODO: alias_maps probably belongs here, too: #}
 {%- set processed_parameters = [
-        'aliases_file',
         'virtual_alias_maps',
         'smtp_sasl_password_maps',
         'sender_canonical_maps',
@@ -74,6 +74,7 @@
 {%- endif %}
 
 {{ set_parameter('myhostname', grains['fqdn']) }}
+{#- TODO: The following two may not be the same: #}
 {{ set_parameter('alias_maps', 'hash:' ~ postfix.aliases_file) }}
 {{ set_parameter('alias_database', 'hash:' ~ postfix.aliases_file) }}
 {{ set_parameter('mydestination', [grains['fqdn'], 'localhost', 'localhost.localdomain', grains['domain']]) }}

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -1,6 +1,11 @@
 {%- from "postfix/map.jinja" import postfix with context -%}
 {%- set config = salt['pillar.get']('postfix:config', {}) -%}
-{% set processed_parameters = ['aliases_file', 'virtual', 'sasl_passwd', 'sender_canonical'] %}
+{%- set processed_parameters = [
+        'aliases_file',
+        'virtual_alias_maps',
+        'smtp_sasl_password_maps',
+        'sender_canonical_maps',
+    ] %}
 {%- macro set_parameter(parameter, default=None) -%}
 {% set value = config.get(parameter, default) %}
 {%- if value is not none %}

--- a/postfix/files/mapping.j2
+++ b/postfix/files/mapping.j2
@@ -1,11 +1,14 @@
 # Managed by config management
 
+{%- if colon is not defined %}
+  {%- set colon = False %}
+{%- endif %}
 {%- macro format_value(key, value) %}
   {#- Some settings, like virtual_alias_maps can take multiple values. Handle this case. -#}
   {%- if value is iterable and value is not string -%}
-{{ key }}	{{ value|join(", ") }}
+{{ key }}{% if colon %}:{% endif %}	{{ value|join(", ") }}
   {%- else -%}
-{{ key }}	{{ value }}
+{{ key }}{% if colon %}:{% endif %}	{{ value }}
   {%- endif -%}
 {%- endmacro %}
 

--- a/postfix/files/mapping.j2
+++ b/postfix/files/mapping.j2
@@ -1,5 +1,7 @@
 # Managed by config management
-
+{#- Some files (mainly the aliases one) require key and values
+    to be separated with a colon. For this `colon: True` should
+    be passed to the template #}
 {%- if colon is not defined %}
   {%- set colon = False %}
 {%- endif %}

--- a/postfix/files/master.cf
+++ b/postfix/files/master.cf
@@ -133,5 +133,5 @@ scache    unix  -       -       n       -       1       scache
 #  ${nexthop} ${user}
 {% if salt['pillar.get']('postfix:policyd-spf:enabled', False) %}
 policy-spf  unix  -       n       n       -       -       spawn
-  user=nobody argv=/usr/bin/policyd-spf
+  user=nobody argv={{ xbin_prefix }}/bin/policyd-spf
 {%- endif %}

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -33,7 +33,7 @@ postfix_alias_database:
     - name: {{ file_path }}
     - source: salt://postfix/aliases
     - user: root
-    - group: root
+    - group: {{ postfix.root_grp }}
     - mode: 644
     - template: jinja
     - require:
@@ -77,7 +77,7 @@ postfix_{{ mapping }}:
     - name: {{ file_path }}
     - source: salt://postfix/files/mapping.j2
     - user: root
-    - group: root
+    - group: {{ postfix.root_grp }}
     {%- if mapping.endswith('_sasl_password_maps') %}
     - mode: 600
     {%- else %}
@@ -90,7 +90,7 @@ postfix_{{ mapping }}:
       - pkg: postfix
   {%- if need_postmap %}
   cmd.wait:
-    - name: /usr/sbin/postmap {{ file_path }}
+    - name: {{ postfix.xbin_prefix }}/sbin/postmap {{ file_path }}
     - cwd: /
     - watch:
       - file: {{ file_path }}

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -31,11 +31,14 @@ postfix:
 postfix_alias_database:
   file.managed:
     - name: {{ file_path }}
-    - source: salt://postfix/aliases
+    - source: salt://postfix/files/mapping.j2
     - user: root
     - group: {{ postfix.root_grp }}
     - mode: 644
     - template: jinja
+    - context:
+        data: {{ salt['pillar.get']('postfix:aliases:present') }}
+        colon: True
     - require:
       - pkg: postfix
   {%- if need_newaliases %}

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -72,6 +72,9 @@ postfix_alias_absent_{{ user }}:
   {%- else %}
     {%- set file_type = default_database_type %}
   {%- endif %}
+  {%- if not file_path.startswith('/') %}
+    {%- set file_path = postfix.config_path ~ '/' ~ file_path %}
+  {%- endif %}
   {%- if file_type in ("btree", "cdb", "dbm", "hash", "sdbm") %}
     {%- set need_postmap = True %}
   {%- endif %}

--- a/postfix/map.jinja
+++ b/postfix/map.jinja
@@ -1,36 +1,74 @@
-{% set postfix = salt['grains.filter_by']({
+# -*- coding: utf-8 -*-
+# vim: ft=jinja
+
+{%- macro deep_merge(a, b) %}
+{#-     This whole `'dict' in x.__class__.__name__` mess is a
+        workaround for the missing mapping test in CentOS 6's
+        ancient Jinja2, see #193  #}
+{%-     for k,v in b.iteritems() %}
+{%-         if v is string or v is number %}
+{%-             do a.update({ k: v }) %}
+{%-         elif 'dict' not in v.__class__.__name__ %}
+{%-             if a[k] is not defined %}
+{%-                 do a.update({ k: v }) %}
+{%-             elif a[k] is iterable and 'dict' not in a[k].__class__.__name__ and
+                a[k] is not string %}
+{%-                 do a.update({ k: v|list + a[k]|list}) %}
+{%-             else %}
+{%-                 do a.update({ k: v }) %}
+{%-             endif %}
+{%-         elif 'dict' in v.__class__.__name__ %}
+{%-             if a[k] is not defined %}
+{%-                 do a.update({ k: v }) %}
+{%-             elif 'dict' in a[k].__class__.__name__ %}
+{%-                 do a.update({ k: v }) %}
+{%-             else %}
+{%-                 do deep_merge(a[k], v) %}
+{%-             endif %}
+{%-         else %}
+{%-            do a.update({ k: 'ERROR: case not contempled in merging!' }) %}
+{%-         endif %}
+{%-     endfor %}
+{%- endmacro %}
+
+
+{## Start with  defaults from defaults.yaml ##}
+{% import_yaml "postfix/defaults.yaml" as default_settings %}
+
+{##
+Setup variable using grains['os_family'] based logic, only add key:values here
+that differ from whats in defaults.yaml
+##}
+{% set osrelease = salt['grains.get']('osrelease') %}
+{# set salt_release = salt['pillar.get']('salt:release', 'latest') #}
+{# set postfix = salt['grains.filter_by'](#}
+{% set os_family_map = salt['grains.filter_by']({
     'Debian': {
-        'package': 'postfix',
         'policyd_spf_pkg': 'postfix-policyd-spf-python',
-        'postsrsd_pkg': 'postsrsd',
-        'postgrey_pkg': 'postgrey',
         'pcre_pkg': 'postfix-pcre',
         'mysql_pkg': 'postfix-mysql',
-        'service': 'postfix',
-        'aliases_file': '/etc/aliases',
     },
     'Gentoo': {
         'package': 'mail-mta/postfix',
         'policyd_spf_pkg': 'mail-filter/pypolicyd-spf',
-        'postsrsd_pkg': 'mail-filter/postsrsd',
         'postgrey_pkg': 'mail-filter/postgrey',
-        'service': 'postfix',
+        'postsrsd_pkg': 'mail-filter/postsrsd',
         'aliases_file': '/etc/mail/aliases',
     },
     'RedHat': {
-        'package': 'postfix',
         'policyd_spf_pkg': 'pypolicyd-spf',
-        'postsrsd_pkg': 'postsrsd',
-        'postgrey_pkg': 'postgrey',
-        'service': 'postfix',
-        'aliases_file': '/etc/aliases',
     },
     'Arch' : {
-        'package': 'postfix',
         'policyd_spf_pkg': 'python-postfix-policyd-spf',
-        'postsrsd_pkg': 'postsrsd',
-        'postgrey_pkg': 'postgrey',
-        'service': 'postfix',
-        'aliases_file': '/etc/aliases',
     },
 }, merge=salt['pillar.get']('postfix:lookup')) %}
+
+{## Merge the flavor_map to the default settings ##}
+{% do deep_merge(default_settings.postfix, os_family_map) %}
+
+{## Merge in postfix:lookup pillar ##}
+{% set postfix = salt['pillar.get'](
+    'postfix',
+    default=default_settings.postfix,
+    merge=True)
+%}

--- a/postfix/map.jinja
+++ b/postfix/map.jinja
@@ -61,6 +61,13 @@ that differ from whats in defaults.yaml
     'Arch' : {
         'policyd_spf_pkg': 'python-postfix-policyd-spf',
     },
+    'FreeBSD' : {
+        'policyd_spf_pkg': 'py27-postfix-policyd-spf-python',
+        'aliases_file': '/etc/mail/aliases',
+        'xbin_prefix': '/usr/local',
+        'config_path': '/usr/local/etc/postfix',
+        'root_grp': 'wheel',
+    },
 }, merge=salt['pillar.get']('postfix:lookup')) %}
 
 {## Merge the flavor_map to the default settings ##}


### PR DESCRIPTION
Hi @EvaSDK, @davidkarlsen, @imran1008,

I had to adjust quite a bit to add support for FreeBSD so the diff
became rather big so I'm pinging you main contributors here.

Would be great if someone can check if those changes won't
break existing setups. The actual changes to managed files
should be rather limited like some options in `main.cf` moving
around because of the for-loop I added in 8eed2547735865.

The FreeBSD jail I've made this changes for isn't in production
yet as I have to add things like spamfilters first but it's happily
sending cron mails already.

Regards, Florian

PS: @aboe76 looks like I can't request reviews from these guys??