### PR TITLE
master.cf: submission: CSV must not use blank

### DIFF
--- a/postfix/files/master.cf
+++ b/postfix/files/master.cf
@@ -24,7 +24,7 @@
                 parameter, value)) -%}
 {%-       elif value is iterable -%}
 {%-         do additional_services['submission']['args'].append('-o %s=%s' % (
-                parameter, ', '.join(value))) -%}
+                parameter, ','.join(value))) -%}
 {%-       endif -%}
 {%-     endfor -%}
 {%-   else -%}


### PR DESCRIPTION
When using i.e. 

```yaml
postfix:
  manage_master_config: True
  master_config:
    enable_submission: False
    submission:
      smtpd_recipient_restrictions:
        - reject_unknown_recipient_domain
        - reject_non_fqdn_recipient
        - permit_sasl_authenticated
        - reject
```

the template uses `", "` (notice the blank) to join the list. This results in

> fatal: unexpected command-line argument: nameofsetting,

This one-character PR fixes the bug.