### PR TITLE
add inet_protocols

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -59,6 +59,7 @@ postfix:
     mailbox_size_limit: 0
     recipient_delimiter: +
     inet_interfaces: all
+    inet_protocols: all
 
     #postsrsd:
     sender_canonical_maps: tcp:127.0.0.1:10001

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -94,6 +94,7 @@
 {{ set_parameter('mailbox_size_limit', '0') }}
 {{ set_parameter('recipient_delimiter', '+') }}
 {{ set_parameter('inet_interfaces', 'all') }}
+{{ set_parameter('inet_protocols', 'all') }}
 {{ set_parameter('message_size_limit', '41943040') }}
 
 {%- if config.get('relayhost') %}


### PR DESCRIPTION
Allow to disable ipv6/ipv4

Ref. https://unix.stackexchange.com/questions/64414/ipv6-support-is-disabled-warnings
