### PR TITLE
Fix duplicated mapping parameters on main.cf

### DIFF
--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -129,7 +129,7 @@ policy-spf_time_limit = {{ policyd_spf.get('time_limit', '3600s') }}
     {%- set file_path = postfix.config_path ~ '/' ~ file_path %}
   {%- endif %}
 
-{{ mapping }} = {{ file_type }}:{{ file_path }}
+{{ set_parameter(mapping, file_type ~ ':' ~ file_path) }}
 {% endfor %}
 
 {# Accept arbitrary parameters -#}


### PR DESCRIPTION
Fixes the creation of duplicated parameters on main.cf by using the
"set_parameter" macro to append the mapping parameter to the
"processed_parameters" list.