### PR TITLE
Reload postfix service by default.

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -36,6 +36,7 @@ postfix:
         chroot: True
 
   enable_service: True
+  reload_service: True
 
   postgrey:
     enabled: True

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -11,6 +11,7 @@ postfix:
       - service: postfix
   service.running:
     - enable: {{ salt['pillar.get']('postfix:enable_service', True) }}
+    - reload: {{ salt['pillar.get']('postfix:reload_service', True) }}
     - require:
       - pkg: postfix
     - watch:


### PR DESCRIPTION
The postfix service is currently being restarted whenever a
config item changes.
This is unnecessary as the postfix service can reload a new
config.

Set reload: True to prevent unnecessary restarts of the service.
The old behavior can be restored by setting the pillar key
reload_service to False.