### PR TITLE
Improve handling of multiple values in main.cf

### DIFF
--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -19,7 +19,7 @@
   {%- if value is number or value is string -%}
 {{ parameter }} = {{ value }}
   {%- elif value is iterable -%}
-{{ parameter }} = {{ value | join(', ')}}
+{{ parameter }} = {{ value | join('\n') | indent(parameter | length + 3) }}
   {%- endif -%}
 {%- do processed_parameters.append(parameter) %}
 {%- endif %}


### PR DESCRIPTION
In case a list of items (iterable) is passed to the set_parameter
function in main.cf, the list of items are joined by a comma.

This makes parameters with many items a bit hard to read as it
results in long lines.

Postfix also supports an alternative declaration where subsequent
parameter values are written in a new line that starts with whitespace
and thus forms a continuation of the previous line.
This makes parsing multiple entry lines easier for humans.

Old style:
```
smtpd_milters = { unix:/run/spamass-milter/postfix/sock, connect_timeout=10s, default_action=accept } { inet:localhost:10003, connect_timeout=10s, default_action=accept } { inet:localhost:10004, connect_timeout=10s, default_action=accept } { inet:localhost:10006, connect_timeout=10s, default_action=accept } { inet:localhost:10007, connect_timeout=10s, default_action=accept }
```

New style:
```
smtpd_milters = { unix:/run/spamass-milter/postfix/sock, connect_timeout=10s, default_action=accept }
                { inet:localhost:10003, connect_timeout=10s, default_action=accept }
                { inet:localhost:10004, connect_timeout=10s, default_action=accept }
                { inet:localhost:10006, connect_timeout=10s, default_action=accept }
                { inet:localhost:10007, connect_timeout=10s, default_action=accept }
```