### PR TITLE
Fix table type for proxy tables

### DIFF
--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -120,7 +120,10 @@ policy-spf_time_limit = {{ policyd_spf.get('time_limit', '3600s') }}
 
 {%- for mapping, data in salt['pillar.get']('postfix:mapping', {}).items() %}
   {%- set file_path = salt['pillar.get']('postfix:config:' ~ mapping) %}
-  {%- if ':' in file_path %}
+  {%- if file_path.startswith('proxy:') %}
+    {#- Discard the proxy:-prefix #}
+    {%- set _, file_type, file_path = file_path.split(':') %}
+  {%- elif ':' in file_path %}
     {%- set file_type, file_path = file_path.split(':') %}
   {%- else %}
     {%- set file_type = default_database_type %}

--- a/postfix/init.sls
+++ b/postfix/init.sls
@@ -76,7 +76,10 @@ postfix_alias_absent_{{ user }}:
 {% for mapping, data in salt['pillar.get']('postfix:mapping', {}).items() %}
   {%- set need_postmap = False %}
   {%- set file_path = salt['pillar.get']('postfix:config:' ~ mapping) %}
-  {%- if ':' in file_path %}
+  {%- if file_path.startswith('proxy:') %}
+    {#- Discard the proxy:-prefix #}
+    {%- set _, file_type, file_path = file_path.split(':') %}
+  {%- elif ':' in file_path %}
     {%- set file_type, file_path = file_path.split(':') %}
   {%- else %}
     {%- set file_type = default_database_type %}


### PR DESCRIPTION
http://www.postfix.org/DATABASE_README.html#types specifies the lookup
table types postfix understands.

Most are defined as type:/path/to/table which is currently supported
by the postfix formula.

This does break though as soon as the proxy table type is used which is
a prefix to a normal table definition to indicate caching is requested.

This PR changes the code to discard the proxy prefix to ensure that the
usual logic applies again.