### PR TITLE
Postfix must restart if master.cf changes

### DIFF
--- a/postfix/config.sls
+++ b/postfix/config.sls
@@ -71,6 +71,7 @@ include:
       - pkg: postfix
     - watch_in:
       - service: postfix
+      - module: postfix_restart
     - template: jinja
 {% endif %}
 
@@ -116,3 +117,12 @@ postfix_{{ domain }}_ssl_key:
        - service: postfix
 
 {% endfor %}
+
+# Inert by default.
+# Can be used by other states to trigger a restart.
+postfix_restart:
+  module.wait:
+    - name: service.restart
+    - m_name: postfix
+    - require:
+      - service: postfix


### PR DESCRIPTION
I was configuring Postfix to run as a null client (which does not listen on 25/tcp).
The socket only was closed when I manually did a `service postfix restart`.

So when `master.cf` changes it's appropriate to restart (instead of reload) Postfix.
This is a follow-up to #74.

Tested on

- Ubuntu 18.04.5
- FreeBSD 11.2 

@ixs this may be of interest to you.