### PR TITLE
Add additinoal internal services

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,6 +43,23 @@ provisioner:
     postfix.sls:
       postfix:
          manage_master_config: True
+         master_config:
+           services:
+             relay1:
+               wrap: True
+               command: smtp
+               chroot: false
+               type: unix
+               extras: '-o smtp_bind_address=127.0.0.1 -o syslog_name=relay1'
+               no_args: True
+             relay2:
+               wrap: True
+               command: smtp
+               chroot: false
+               type: unix
+               extras: '-o smtp_bind_address=127.0.0.2 -o syslog_name=relay2'
+               no_args: True
+
 
 verifier:
   name: inspec

--- a/pillar.example
+++ b/pillar.example
@@ -22,7 +22,7 @@ postfix:
         enable: True
         chroot: True
       uucp:
-	enable: True
+	      enable: True
       # Dovecot delivery via deliver binary. For better performance, investigate
       # using LMTP instead: <https://wiki.dovecot.org/LMTP>
       dovecot:

--- a/pillar.example
+++ b/pillar.example
@@ -22,7 +22,7 @@ postfix:
         enable: True
         chroot: True
       uucp:
-	      enable: True
+        enable: True
       # Dovecot delivery via deliver binary. For better performance, investigate
       # using LMTP instead: <https://wiki.dovecot.org/LMTP>
       dovecot:

--- a/pillar.example
+++ b/pillar.example
@@ -45,6 +45,9 @@ postfix:
         user: mail
         # Wrap the output in master.cf at 78 chars for better readability
         wrap: True
+        # Avoid user and arvg settings to allow define internal processes
+        # needed for randomizing relay IP (randmap functionality)
+        no_args: True
 
     # Backwards compatible definition of dovecot delivery in master.cf
     enable_dovecot: False

--- a/postfix/files/master.cf
+++ b/postfix/files/master.cf
@@ -130,6 +130,9 @@ y
                                                service_param(service, service_name, 'wakeup'),
                                                service_param(service, service_name, 'maxproc'),
                                                service_param(service, service_name, 'command', service_name)) }}
+{%-   if 'no_args' in service -%}
+{%-     set parameter_str = "%s %s" | format(comment,service_param(service, service_name, 'extras', '')) -%}
+{%-   else -%}
 {%-   if 'flags' in service or 'flags' in postfix_master_services.defaults[service_name] -%}
 {%-     set parameter_str = "%s  flags=%s user=%s argv=%s %s" | format(comment,
                                             service_param(service, service_name, 'flags'),
@@ -142,6 +145,7 @@ y
                                             service_param(service, service_name, 'argv'),
                                             service_param(service, service_name, 'extras', '')) -%}
 {%-   endif -%}
+{%-   endif -%}{# if 'no_args' in service #}
 {%-   if wrap %}
 {{      parameter_str | wordwrap(width=wrap, break_long_words=False, wrapstring='\n%s  ' | format(comment)) }}
 {%-   else %}


### PR DESCRIPTION
Add switch no_args to allow define also internal services without user= and argv=.
It is needed for example for creation from several relay services and using them with randmap.