### PR TITLE
Fix #89 by ignoring only keys which are actually used in Pillar 'postfix:mapping'

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -235,3 +235,24 @@ postfix:
         - someuser_1@example.com
         - someuser_2@example.com
       - singlealiasexample: someuser_3@example.com
+
+
+###
+#
+# Multiple virtual_alias_maps entries:
+#
+# You are free to define alternative mapping names
+# and use them as 'variables' in your Postfix config:
+# (Credit for the idea and the example goes to @roskens.)
+
+postfix:
+  config:
+    virtual_alias_maps: $virtual_alias_1_maps $virtual_alias_2_maps
+    virtual_alias_1_maps: hash:/etc/postfix/virtual
+    virtual_alias_2_maps: pcre:/etc/postfix/virtual.pcre
+  mapping:
+    virtual_alias_1_maps:
+      root:
+        - me
+    virtual_alias_2_maps:
+      - '/(\S+)_(devel|preprod|prod)@sub.example.com$/': '$(1)@$(2).sub.example.com' 

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -1,17 +1,8 @@
 {%- from "postfix/map.jinja" import postfix with context -%}
 {%- set config = salt['pillar.get']('postfix:config', {}) -%}
 
-{%- if not salt['pillar.get']('postfix:mapping', False) %}
-{#- Let the user configure mapping manually. -#}
-{%- set processed_parameters = [] %}
-{%- else -%}
-{#- TODO: alias_maps probably belongs here, too: #}
-{%- set processed_parameters = [
-        'virtual_alias_maps',
-        'smtp_sasl_password_maps',
-        'sender_canonical_maps',
-    ] %}
-{%- endif -%}
+{#- " | list": Python3.6 retuns dict_keys here, which needs to be converted into a list here. -#}
+{%- set processed_parameters = salt['pillar.get']('postfix:mapping', {}).keys() | list %}
 
 {%- macro set_parameter(parameter, default=None) -%}
 {% set value = config.get(parameter, default) %}

--- a/postfix/files/mapping.j2
+++ b/postfix/files/mapping.j2
@@ -21,6 +21,7 @@
 {%- else %}
 {#- Some settings need order, handle OrderedDict #}
 {% for item in data %}
-{{ format_value(item.keys()[0], item.values()[0]) }}
+{%-   set key, value = item.popitem() %}
+{{ format_value(key, value) }}
 {%- endfor -%}
 {%- endif %}


### PR DESCRIPTION
With this change the following becomes feasible:

```yaml
postfix:
  config:
    virtual_alias_maps: "$my_va_map"
    my_va_map: hash:{{ pillar['userland_etc'] }}/postfix/virtual_alias_maps
  mapping:
    # previously: 'virtual_alias_maps:'
    my_va_map:
      - '@example.test': catchall@example.test
```

resulting in

```yaml
----------                                                                                                
          ID: /usr/local/etc/postfix/main.cf                                                              
    Function: file.managed                                                                                
      Result: True                                                                                        
     Comment: File /usr/local/etc/postfix/main.cf updated                                                 
     Started: 20:22:32.857905                                                                             
    Duration: 157.56 ms                                                                                   
     Changes:                                                                                             
              ----------                                                                                  
              diff:                                                                                       
                  ---                                                                                     
                  +++                                                                                     
                  @@ -70,7 +70,7 @@                                                                       
                                                                                                          
                                                                                                          
                                                                                                          
                  -virtual_alias_maps = hash:/usr/local/etc/postfix/virtual_alias_maps
                  +my_va_map = hash:/usr/local/etc/postfix/virtual_alias_maps
                   
                   
                   tls_high_cipherlist = EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH:+
CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH
                  @@ -89,6 +89,7 @@
                   smtpd_tls_protocols = !SSLv2, !SSLv3
                   smtpd_tls_session_cache_timeout = 3600s
                   strict_rfc821_envelopes = yes
                  +virtual_alias_maps = $my_va_map
                   virtual_mailbox_maps = 
                   virtual_transport = lmtp:unix:private/dovecot-lmtp
                   virtual_mailbox_domains = dmz.tty1.eu
```

This allows also for multiple maps within `virtual_alias_maps` as mentioned in #89 and https://github.com/saltstack-formulas/postfix-formula/issues/83#issuecomment-463342748 by @roskens.

----

I also fixed `mapping.j2` along the way. It didn't work with Python 3.6.

----

Tested on FreeBSD 11.2.