### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/default.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  key-duplicates:
+    ignore: |
+      pillar.example
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,8 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 postfix:
-  manage_master_config: True
+  manage_master_config: true
   master_config:
     # Preferred way of managing services/processes. This allows for finegrained
     # control over each service. See postfix/services.yaml for defaults that can
@@ -10,29 +13,29 @@ postfix:
         maxproc: 10
       # Enable oldstyle TLS wrapped SMTP
       smtps:
-        enable: True
+        enable: true
       # Enable submission service on port 587/tcp with custom options
       submission:
-        enable: True
+        enable: true
         args:
           - "-o smtpd_tls_security_level=encrypt"
           - "-o smtpd_sasl_auth_enable=yes"
           - "-o smtpd_client_restrictions: permit_sasl_authenticated,reject"
       tlsproxy:
-        enable: True
-        chroot: True
+        enable: true
+        chroot: true
       uucp:
-        enable: True
+        enable: true
       # Dovecot delivery via deliver binary. For better performance, investigate
       # using LMTP instead: <https://wiki.dovecot.org/LMTP>
       dovecot:
-        chroot: False
+        chroot: false
         command: pipe
-        enable: True
+        enable: true
         extras: '-d ${recipient}'
         flags: DRhu
         type: unix
-        unpriv: False
+        unpriv: false
         user: vmail:vmail
         argv: /usr/lib/dovecot/deliver
       # Completely customized mail-delivery-agent entry. Will be appended to the
@@ -44,13 +47,13 @@ postfix:
         flags: DRhu
         user: mail
         # Wrap the output in master.cf at 78 chars for better readability
-        wrap: True
+        wrap: true
         # Avoid user and arvg settings to allow define internal processes
         # needed for randomizing relay IP (randmap functionality)
-        no_args: True
+        no_args: true
 
     # Backwards compatible definition of dovecot delivery in master.cf
-    enable_dovecot: False
+    enable_dovecot: false
     # The following are the default values:
     dovecot:
       user: vmail
@@ -59,23 +62,23 @@ postfix:
       argv: "/usr/lib/dovecot/deliver"
 
     # Backwards compatible definition of submission listener in master.cf
-    enable_submission: False
+    enable_submission: false
     # To replace the defaults use this:
     submission:
       smtpd_tls_security_level: encrypt
-      smtpd_sasl_auth_enable: yes
+      smtpd_sasl_auth_enable: 'yes'
       smtpd_client_restrictions: permit_sasl_authenticated,reject
 
-  enable_service: True
-  reload_service: True
+  enable_service: true
+  reload_service: true
 
   postgrey:
-    enabled: True
-    enable_service: True
+    enabled: true
+    enable_service: true
     location: inet:172.16.0.5:6379
 
   policyd-spf:
-    enabled: True
+    enabled: true
     time_limit: 7200s
 
   config:
@@ -86,14 +89,14 @@ postfix:
     readme_directory: 'no'
     myhostname: localhost
     mydestination: localhost, localhost.localdomain
-    relayhost: 
+    relayhost:
     mynetworks: 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
     mailbox_size_limit: 0
     recipient_delimiter: +
     inet_interfaces: all
     inet_protocols: all
 
-    #postsrsd:
+    # postsrsd:
     sender_canonical_maps: tcp:127.0.0.1:10001
     sender_canonical_classes: envelope_sender
     recipient_canonical_maps: tcp:127.0.0.1:10002
@@ -127,8 +130,14 @@ postfix:
     smtpd_sasl_auth_enable: 'yes'
     smtpd_sasl_type: dovecot
     smtpd_sasl_path: /var/run/dovecot/auth-client
-    smtpd_recipient_restrictions: permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination
-    smtpd_relay_restrictions: permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination
+    smtpd_recipient_restrictions: >-
+      permit_mynetworks,
+      permit_sasl_authenticated,
+      reject_unauth_destination
+    smtpd_relay_restrictions: >-
+      permit_mynetworks,
+      permit_sasl_authenticated,
+      reject_unauth_destination
     smtpd_sasl_security_options: noanonymous
     smtpd_sasl_tls_security_options: $smtpd_sasl_security_options
     smtpd_tls_auth_only: 'yes'
@@ -232,8 +241,8 @@ postfix:
 
     virtual_alias_maps:
       - groupaliasexample:
-        - someuser_1@example.com
-        - someuser_2@example.com
+          - someuser_1@example.com
+          - someuser_2@example.com
       - singlealiasexample: someuser_3@example.com
 
 
@@ -255,4 +264,4 @@ postfix:
       root:
         - me
     virtual_alias_2_maps:
-      - '/(\S+)_(devel|preprod|prod)@sub.example.com$/': '$(1)@$(2).sub.example.com' 
+      - '/(\S+)_(devel|preprod|prod)@sub.example.com$/': '$(1)@$(2).sub.example.com'

--- a/postfix/defaults.yaml
+++ b/postfix/defaults.yaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
-
+---
 postfix:
   aliases_file: /etc/aliases
   config_path: /etc/postfix

--- a/postfix/osfamilymap.yaml
+++ b/postfix/osfamilymap.yaml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 Arch:
   policyd_spf_pkg: python-postfix-policyd-spf
 

--- a/postfix/services.yaml
+++ b/postfix/services.yaml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 #  Default Postfix master processes as defined by postfix
 #
 # The dictionary is keyed off the service name ("smtp", "smtpd", etc.) except
@@ -9,7 +12,7 @@
 #
 
 defaults:
-# Postfix internal services/processes defaults
+  # Postfix internal services/processes defaults
   smtp:
     chroot: false
     command: smtpd
@@ -218,7 +221,7 @@ defaults:
     maxproc: 1
     type: unix
 
-# Postfix MDA definitions, these are optional and commented out by default
+  # Postfix MDA definitions, these are optional and commented out by default
   maildrop:
     argv: /usr/local/bin/maildrop
     chroot: false

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: postfix formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix (or ignore) errors shown below:

```bash
postfix-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./postfix/osfamilymap.yaml
  1:1       warning  missing document start "---"  (document-start)

./postfix/services.yaml
  11:1      warning  missing document start "---"  (document-start)
  12:1      warning  comment not indented like content  (comments-indentation)
  221:1     warning  comment not indented like content  (comments-indentation)

./postfix/defaults.yaml
  4:1       warning  missing document start "---"  (document-start)

pillar.example
  1:1       warning  missing document start "---"  (document-start)
  2:25      warning  truthy value should be one of [false, true]  (truthy)
  13:17     warning  truthy value should be one of [false, true]  (truthy)
  16:17     warning  truthy value should be one of [false, true]  (truthy)
  22:17     warning  truthy value should be one of [false, true]  (truthy)
  23:17     warning  truthy value should be one of [false, true]  (truthy)
  25:17     warning  truthy value should be one of [false, true]  (truthy)
  29:17     warning  truthy value should be one of [false, true]  (truthy)
  31:17     warning  truthy value should be one of [false, true]  (truthy)
  35:17     warning  truthy value should be one of [false, true]  (truthy)
  47:15     warning  truthy value should be one of [false, true]  (truthy)
  50:18     warning  truthy value should be one of [false, true]  (truthy)
  53:21     warning  truthy value should be one of [false, true]  (truthy)
  62:24     warning  truthy value should be one of [false, true]  (truthy)
  66:31     warning  truthy value should be one of [false, true]  (truthy)
  69:19     warning  truthy value should be one of [false, true]  (truthy)
  70:19     warning  truthy value should be one of [false, true]  (truthy)
  73:14     warning  truthy value should be one of [false, true]  (truthy)
  74:21     warning  truthy value should be one of [false, true]  (truthy)
  78:14     warning  truthy value should be one of [false, true]  (truthy)
  89:15     error    trailing spaces  (trailing-spaces)
  96:6      warning  missing starting space in comment  (comments)
  130:89    error    line too long (105 > 88 characters)  (line-length)
  131:89    error    line too long (101 > 88 characters)  (line-length)
  152:5     error    duplication of key "sender_canonical_maps" in mapping  (key-duplicates)
  154:5     error    duplication of key "virtual_alias_maps" in mapping  (key-duplicates)
  190:5     error    duplication of key "use_file" in mapping  (key-duplicates)
  235:9     error    wrong indentation: expected 10 but found 8  (indentation)
  248:1     error    duplication of key "postfix" in mapping  (key-duplicates)
  258:85    error    trailing spaces  (trailing-spaces)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.