### PR TITLE
Support client-specific TLS and smtp_tls_wrappermode

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -158,6 +158,7 @@ postfix:
     smtp_tls_cert_file: /etc/postfix/ssl/example.com-relay-client-cert.crt
     smtp_tls_key_file: /etc/postfix/ssl/example.com-relay-client-cert.key
     smtp_tls_policy_maps: hash:/etc/postfix/tls_policy
+    smtp_tls_wrappermode: 'yes'
 
     smtp_sasl_password_maps: hash:/etc/postfix/sasl_passwd
     sender_canonical_maps: hash:/etc/postfix/sender_canonical

--- a/postfix/files/main.cf
+++ b/postfix/files/main.cf
@@ -80,10 +80,13 @@
 {{ set_parameter('smtpd_tls_mandatory_exclude_ciphers', ['aNULL', 'MD5']) }}
 {{ set_parameter('smtpd_tls_mandatory_protocols', ['!SSLv2', '!SSLv3']) }}
 {{ set_parameter('tls_preempt_cipherlist', 'yes') }}
+{%- endif %}
+{%- if config.get('smtpd_use_tls', 'yes') == 'yes' or config.get('smtp_use_tls', 'no') == 'yes' %}
 # Relay/Sender settings
 {{ set_parameter('smtp_tls_loglevel', 1) }}
 {{ set_parameter('smtp_tls_security_level', 'may') }}
 {{ set_parameter('smtp_tls_session_cache_database', 'btree:${data_directory}/smtp_scache') }}
+{{ set_parameter('smtp_tls_wrappermode', 'no') }}
 {%- endif %}
 
 {{ set_parameter('myhostname', grains['fqdn']) }}

--- a/test/integration/default/controls/postfix_spec.rb
+++ b/test/integration/default/controls/postfix_spec.rb
@@ -63,6 +63,7 @@ control 'Postfix config' do
     its('smtpd_tls_session_cache_timeout') { should cmp '3600s' }
     its('relay_domains') { should cmp '$mydestination' }
     its('smtp_use_tls') { should cmp 'yes' }
+    its('smtp_tls_wrappermode') { should cmp 'yes' }
     its('smtp_tls_cert_file') do
       should cmp '/etc/postfix/ssl/example.com-relay-client-cert.crt'
     end

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -98,6 +98,7 @@ postfix:
     smtp_tls_cert_file: /etc/postfix/ssl/example.com-relay-client-cert.crt
     smtp_tls_key_file: /etc/postfix/ssl/example.com-relay-client-cert.key
     smtp_tls_policy_maps: hash:/etc/postfix/tls_policy
+    smtp_tls_wrappermode: 'yes'
 
     smtp_sasl_password_maps: hash:/etc/postfix/sasl_passwd
     sender_canonical_maps: hash:/etc/postfix/sender_canonical


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

- allow configuration of client TLS without enabling server specific TLS options
- allow use of `smtp_tls_wrappermode` configuration option


### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

```
postfix:
  config:
    smtpd_tls_true: 'no'
    smtp_tls_true:  'yes'
    smtp_tls_wrappermode: 'yes'
```

The existing `smtpd_tls_true` behavior did not change, so this will work just as well:

```
postfix:
  config:
    smtp_tls_wrappermode: 'yes'
```

```
postfix:
  config:
    smtpd_tls_true:  'yes'
    smtp_tls_wrappermode: 'yes'
```

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

<details>
<summary>Output</summary>

```
[DEBUG   ] Results of YAML rendering: 
OrderedDict([('salt', OrderedDict([('clean_config_d_dir', False), ('minion_remove_config', True), ('minion', OrderedDict([('master_type', 'str')]))]))])
[PROFILE ] Time (in seconds) to render '/srv/pillar/role/salt/minion.sls' using 'yaml' renderer: 0.0011065006256103516
[DEBUG   ] compile template: /srv/pillar/common/suse.sls
[DEBUG   ] Jinja search path: ['/srv/pillar', '/srv/spm/pillar']
[PROFILE ] Time (in seconds) to render '/srv/pillar/common/suse.sls' using 'jinja' renderer: 0.0007901191711425781
[DEBUG   ] Rendered data from file: /srv/pillar/common/suse.sls:
include:
  - .postfix

zypper:
  refreshdb_force: False

[DEBUG   ] Results of YAML rendering: 
OrderedDict([('include', ['.postfix']), ('zypper', OrderedDict([('refreshdb_force', False)]))])
[PROFILE ] Time (in seconds) to render '/srv/pillar/common/suse.sls' using 'yaml' renderer: 0.0009088516235351562
[DEBUG   ] compile template: /srv/pillar/common/postfix.sls
[DEBUG   ] Jinja search path: ['/srv/pillar', '/srv/spm/pillar']
[PROFILE ] Time (in seconds) to render '/srv/pillar/common/postfix.sls' using 'jinja' renderer: 0.0018353462219238281
[DEBUG   ] Rendered data from file: /srv/pillar/common/postfix.sls:
postfix:
  master_config:
    services:
      smtp:
        enable: False
      tlsproxy:
        enable: True
  config:
    # to-do: set via site config
    relayhost: zz0.email
    myhostname: bd5de19d49b1
    inet_interfaces: loopback-only
    # to-do: support relay via IPv6
    inet_protocols: ipv4
    alias_maps: lmdb:/etc/aliases
    smtpd_use_tls: 'no'
    smtp_use_tls: 'yes'
    smtp_tls_security_level: encrypt
    smtp_tls_wrappermode: 'yes'

[DEBUG   ] Results of YAML rendering: 
OrderedDict([('salt', OrderedDict([('master', OrderedDict([('syndic_user', 'salt'), ('syndic_master', "${'secret_salt:master:syndic_master'}")]))]))])
[PROFILE ] Time (in seconds) to render '/srv/pillar/role/salt/syndic.sls' using 'yaml' renderer: 0.0009541511535644531
[DEBUG   ] Skipping ignored and missing SLS 'role.lighttpd' in environment 'base'
[DEBUG   ] Skipping ignored and missing SLS 'role.matterbridge' in environment 'base'
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] LazyLoaded state.apply
[DEBUG   ] LazyLoaded direct_call.execute
[DEBUG   ] LazyLoaded saltutil.is_running
[DEBUG   ] Override  __grains__: <module 'salt.loaded.int.module.grains' from '/usr/lib/python3.6/site-packages/salt/modules/grains.py'>
[DEBUG   ] LazyLoaded grains.get
[DEBUG   ] LazyLoaded config.get
[DEBUG   ] LazyLoaded roots.envs
[DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
[DEBUG   ] Updating roots fileserver cache
[DEBUG   ] Gathering pillar data for state run
[DEBUG   ] Finished gathering pillar data for state run
[INFO    ] Loading fresh modules for state activity
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] Unable to list dir: /srv/salt/top.sls
[DEBUG   ] Unable to list dir: /srv/salt/_modules/nbroles.py
[DEBUG   ] Unable to list dir: /srv/salt/common/init.sls
[DEBUG   ] Unable to list dir: /srv/salt/common/suse.sls
[DEBUG   ] Unable to list dir: /srv/salt/profile/lighttpd/init.sls
[DEBUG   ] Unable to list dir: /srv/salt/profile/lighttpd/files/etc/lighttpd/lighttpd.conf.j2
[DEBUG   ] Unable to list dir: /srv/salt/profile/lighttpd/files/etc/lighttpd/vhosts.conf.j2
[DEBUG   ] Unable to list dir: /srv/salt/profile/matterbridge/init.sls
[DEBUG   ] Unable to list dir: /srv/salt/profile/matterbridge/files/etc/matterbridge/matterbridge.toml.j2
[DEBUG   ] Unable to list dir: /srv/salt/profile/node_exporter/init.sls
[DEBUG   ] Unable to list dir: /srv/salt/profile/salt/grains.sls
[DEBUG   ] Unable to list dir: /srv/salt/profile/salt/master.sls
[DEBUG   ] Unable to list dir: /srv/salt/profile/salt/minion.sls
[DEBUG   ] Unable to list dir: /srv/salt/profile/salt/files/etc/salt/grains.j2
[DEBUG   ] Unable to list dir: /srv/salt/profile/seccheck/init.sls
[DEBUG   ] Unable to list dir: /srv/salt/profile/seccheck/files/etc/security/autologout.conf
[DEBUG   ] Unable to list dir: /srv/salt/profile/seccheck/files/etc/sysconfig/seccheck
[DEBUG   ] Unable to list dir: /srv/salt/profile/zypp/init.sls
[DEBUG   ] Unable to list dir: /srv/salt/profile/zypp/files/etc/zypp/zypp.conf.j2
[DEBUG   ] Unable to list dir: /srv/salt/role/lighttpd.sls
[DEBUG   ] Unable to list dir: /srv/salt/role/matterbridge.sls
[DEBUG   ] Unable to list dir: /srv/salt/role/salt/common.sls
[DEBUG   ] Unable to list dir: /srv/salt/role/salt/master.sls
[DEBUG   ] Unable to list dir: /srv/salt/role/salt/minion.sls
[DEBUG   ] Unable to list dir: /srv/salt/role/salt/syndic.sls
[DEBUG   ] Unable to list dir: /srv/salt/extmods/modules/nbroles.py
[DEBUG   ] Unable to list dir: /srv/salt/extmods/pillar/lookup.py
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.git
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.gitignore
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.gitlab-ci.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.pre-commit-config.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.rstcheck.cfg
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.rubocop.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.salt-lint
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.travis.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.yamllint
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/AUTHORS.md
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/CHANGELOG.md
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/CODEOWNERS
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/FORMULA
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/Gemfile
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/Gemfile.lock
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/LICENSE
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/Vagrantfile
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/commitlint.config.js
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/kitchen.macos.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/kitchen.vagrant.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/kitchen.windows.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/kitchen.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/pillar.example
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/pre-commit_semantic-release.sh
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/release-rules.js
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/release.config.js
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.github/workflows/commitlint.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.github/workflows/kitchen.macos.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.github/workflows/kitchen.vagrant.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/.github/workflows/kitchen.windows.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/bin/install-hooks
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/bin/kitchen
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/dev/pillar_top.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/dev/setup-salt.sh
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/dev/state_top.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/docs/AUTHORS.rst
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/docs/CHANGELOG.rst
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/docs/README.rst
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/docs/TOFS_pattern.rst
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/api.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/cloud.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/defaults.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/formulas.jinja
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/formulas.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/init.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/libtofs.jinja
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/map.jinja
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/master.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/minion.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/osfamilymap.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/osfingermap.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/osmap.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pin.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/ssh.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/standalone.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/syndic.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/_mapdata/_mapdata.jinja
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/_mapdata/init.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/gitfs_key.jinja
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/key
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/roster.jinja
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.maps.d/_ec2.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.maps.d/_gce.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.maps.d/_rsos.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.maps.d/_saltify.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.profiles.d/_ec2.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.profiles.d/_gce.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.profiles.d/_rsos.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.profiles.d/_saltify.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.providers.d/_ec2.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.providers.d/_gce.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.providers.d/_rsos.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/cloud.providers.d/_saltify.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/default/master.d/engine.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/default/master.d/f_defaults.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/default/master.d/lxc_profiles.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/default/master.d/reactor.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/default/minion.d/beacons.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/default/minion.d/engine.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/default/minion.d/f_defaults.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/default/minion.d/reactor.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/master.d/engine.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/master.d/f_defaults.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/master.d/lxc_profiles.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/master.d/reactor.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/minion.d/beacons.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/minion.d/engine.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/minion.d/f_defaults.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/files/minion.d/reactor.conf
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/gitfs/dulwich.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/gitfs/gitpython.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/gitfs/keys.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/gitfs/pygit2.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/absent.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/init.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/arch/clean.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/arch/init.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/arch/install.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/debian/absent.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/debian/clean.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/debian/init.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/debian/install.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/freebsd/clean.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/freebsd/init.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/freebsd/install.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/macos/clean.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/macos/init.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/macos/install.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/redhat/absent.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/redhat/clean.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/redhat/init.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/redhat/install.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/suse/absent.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/suse/clean.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/suse/init.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/salt/pkgrepo/suse/install.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/README.md
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/inspec.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/controls/_mapdata.rb
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/controls/pkgs_spec.rb
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/controls/service_spec.rb
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/almalinux-8.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/amazonlinux-2.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/arch-base-latest.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/centos-7.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/centos-8.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/debian-10.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/debian-11.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/debian-9.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/fedora-33.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/fedora-34.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/fedora-35.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/fedora-36.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/freebsd-12.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/freebsd-13.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/gentoo-2-sysd.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/gentoo-2-sysv.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/mac_os_x-10.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/mac_os_x-11.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/mac_os_x-12.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/openbsd-6.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/openbsd-7.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/opensuse-15.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/opensuse-tumbleweed.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/oraclelinux-7.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/oraclelinux-8.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/rockylinux-8.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/ubuntu-18.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/ubuntu-20.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/windows-10.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/windows-2016-server.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/windows-2019-server.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/windows-2022-server.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/default/files/_mapdata/windows-8.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/share/README.md
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/share/inspec.yml
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/integration/share/libraries/system.rb
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/salt/pillar/salt.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/salt/pillar/top.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/salt/pillar/v3002-py3.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/salt/pillar/v3003-py3.sls
[DEBUG   ] Unable to list dir: /srv/formulas/salt-formula/test/salt/pillar/v3004-py3.sls
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/.git
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/.gitignore
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/.gitlab-ci.yml
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/.pre-commit-config.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/.rstcheck.cfg
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/.rubocop.yml
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/.salt-lint
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/.travis.yml
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/.yamllint
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/AUTHORS.md
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/CHANGELOG.md
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/CODEOWNERS
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/FORMULA
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/Gemfile
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/Gemfile.lock
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/LICENSE
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/commitlint.config.js
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/kitchen.yml
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/pillar.example
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/pre-commit_semantic-release.sh
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/release-rules.js
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/release.config.js
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/.github/workflows/commitlint.yml
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/bin/install-hooks
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/bin/kitchen
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/docs/AUTHORS.rst
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/docs/CHANGELOG.rst
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/docs/README.rst
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/config.sls
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/defaults.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/init.sls
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/iptables-input.sls
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/map.jinja
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/mysql.sls
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/osfamilymap.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/pcre.sls
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/policyd-spf.sls
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/postgrey.sls
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/postsrsd.sls
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/services.yaml
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/_mapdata/_mapdata.jinja
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/_mapdata/init.sls
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/files/main.cf
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/files/mapping.j2
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/files/master.cf
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/files/virtual_alias_maps.cf
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/files/virtual_mailbox_domains.cf
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/postfix/files/virtual_mailbox_maps.cf
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/test/integration/default/README.md
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/test/integration/default/inspec.yml
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/test/integration/default/controls/pkgs_spec.rb
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/test/integration/default/controls/postfix_maps_spec.rb
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/test/integration/default/controls/postfix_maps_type_spec.rb
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/test/integration/default/controls/postfix_spec.rb
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/test/integration/default/controls/service_spec.rb
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/test/integration/share/README.md
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/test/integration/share/inspec.yml
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/test/integration/share/libraries/system.rb
[DEBUG   ] Unable to list dir: /srv/formulas/postfix-formula/test/salt/pillar/default.sls
[DEBUG   ] In saltenv 'production', looking at rel_path 'postfix/config.sls' to resolve 'salt://postfix/config.sls'
[DEBUG   ] In saltenv 'production', ** considering ** path '/var/cache/salt/minion/files/production/postfix/config.sls' to resolve 'salt://postfix/config.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/production/postfix/config.sls
[DEBUG   ] Jinja search path: ['/var/cache/salt/minion/files/production']
[DEBUG   ] In saltenv 'production', looking at rel_path 'postfix/map.jinja' to resolve 'salt://postfix/map.jinja'
[DEBUG   ] In saltenv 'production', ** considering ** path '/var/cache/salt/minion/files/production/postfix/map.jinja' to resolve 'salt://postfix/map.jinja'
[DEBUG   ] In saltenv 'production', looking at rel_path 'postfix/defaults.yaml' to resolve 'salt://postfix/defaults.yaml'
[DEBUG   ] In saltenv 'production', ** considering ** path '/var/cache/salt/minion/files/production/postfix/defaults.yaml' to resolve 'salt://postfix/defaults.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'postfix/defaults.yaml': 0.0038776397705078125
[DEBUG   ] In saltenv 'production', looking at rel_path 'postfix/osfamilymap.yaml' to resolve 'salt://postfix/osfamilymap.yaml'
[DEBUG   ] In saltenv 'production', ** considering ** path '/var/cache/salt/minion/files/production/postfix/osfamilymap.yaml' to resolve 'salt://postfix/osfamilymap.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'postfix/osfamilymap.yaml': 0.0070188045501708984
[DEBUG   ] Override  __grains__: <module 'salt.loaded.int.module.grains' from '/usr/lib/python3.6/site-packages/salt/modules/grains.py'>
[DEBUG   ] LazyLoaded grains.filter_by
[DEBUG   ] LazyLoaded pillar.get
[DEBUG   ] In saltenv 'production', looking at rel_path 'postfix/services.yaml' to resolve 'salt://postfix/services.yaml'
[DEBUG   ] In saltenv 'production', ** considering ** path '/var/cache/salt/minion/files/production/postfix/services.yaml' to resolve 'salt://postfix/services.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'postfix/services.yaml': 0.044965267181396484
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/production/postfix/config.sls' using 'jinja' renderer: 0.08465814590454102
[DEBUG   ] Rendered data from file: /var/cache/salt/minion/files/production/postfix/config.sls:

include:
  - postfix

postfix-config-file-directory-config-path:
  file.directory:
    - name: /etc/postfix
    - user: root
    - group: root
    - dir_mode: '0755'
    - file_mode: '0644'
    - makedirs: True

postfix-config-file-managed-main.cf:
  file.managed:
    - name: /etc/postfix/main.cf
    - source: salt://postfix/files/main.cf
    - user: root
    - group: root
    - mode: '0644'
    - require:
      - pkg: postfix-init-pkg-installed-postfix
    - watch_in:
      - service: postfix-init-service-running-postfix
    - template: jinja
    - context:
        postfix: {"aliases_file": "/etc/aliases", "config_path": "/etc/postfix", "package": "postfix", "postsrsd_pkg": "postsrsd", "postgrey_pkg": "postgrey", "root_grp": "root", "setgid_group": "maildrop", "daemon_directory": "/usr/lib/postfix/bin", "service": "postfix", "xbin_prefix": "/usr", "dovecot_deliver": "/usr/lib/dovecot/deliver", "default_database_type": "hash"}

postfix-config-file-managed-master.cf:
  file.managed:
    - name: /etc/postfix/master.cf
    - source: salt://postfix/files/master.cf
    - user: root
    - group: root
    - mode: '0644'
    - require:
      - pkg: postfix-init-pkg-installed-postfix
    - watch_in:
      - service: postfix-init-service-running-postfix
    - template: jinja
    - context:
        postfix: {"aliases_file": "/etc/aliases", "config_path": "/etc/postfix", "package": "postfix", "postsrsd_pkg": "postsrsd", "postgrey_pkg": "postgrey", "root_grp": "root", "setgid_group": "maildrop", "daemon_directory": "/usr/lib/postfix/bin", "service": "postfix", "xbin_prefix": "/usr", "dovecot_deliver": "/usr/lib/dovecot/deliver", "default_database_type": "hash"}
        postfix_master_services: {"defaults": {"smtp": {"chroot": false, "command": "smtpd", "private": false, "type": "inet"}, "smtp-postscreen": {"chroot": false, "command": "postscreen", "enable": false, "maxproc": 1, "private": false, "service": "smtp", "type": "inet"}, "smtpd": {"chroot": false, "enable": false, "type": "pass"}, "dnsblog": {"chroot": false, "enable": false, "maxproc": 0, "type": "unix"}, "tlsproxy": {"chroot": false, "enable": false, "maxproc": 0, "type": "unix"}, "submission": {"args": ["-o syslog_name=postfix/submission", "-o smtpd_tls_security_level=encrypt", "-o smtpd_sasl_auth_enable=yes", "-o smtpd_reject_unlisted_recipient=no", "-o smtpd_client_restrictions=$mua_client_restrictions", "-o smtpd_helo_restrictions=$mua_helo_restrictions", "-o smtpd_sender_restrictions=$mua_sender_restrictions", "-o smtpd_recipient_restrictions=permit_sasl_authenticated,reject", "-o milter_macro_daemon_name=ORIGINATING"], "chroot": false, "command": "smtpd", "enable": false, "private": false, "type": "inet"}, "smtps": {"args": ["-o syslog_name=postfix/smtps", "-o smtpd_tls_wrappermode=yes", "-o smtpd_sasl_auth_enable=yes", "-o smtpd_reject_unlisted_recipient=no", "-o smtpd_client_restrictions=$mua_client_restrictions", "-o smtpd_helo_restrictions=$mua_helo_restrictions", "-o smtpd_sender_restrictions=$mua_sender_restrictions", "-o smtpd_recipient_restrictions=permit_sasl_authenticated,reject", "-o milter_macro_daemon_name=ORIGINATING"], "chroot": false, "command": "smtpd", "enable": false, "private": false, "type": "inet"}, "628": {"chroot": false, "command": "qmqpd", "enable": false, "private": false, "type": "inet"}, "pickup": {"chroot": false, "maxproc": 1, "private": false, "type": "unix", "wakeup": 60}, "cleanup": {"chroot": false, "maxproc": 0, "private": false, "type": "unix"}, "qmgr": {"chroot": false, "maxproc": 1, "private": false, "type": "unix", "wakeup": 300}, "qmgr-oqmgr": {"chroot": false, "command": "oqmgr", "enable": false, "maxproc": 1, "private": false, "service": "qmgr", "type": "unix", "wakeup": 300}, "tlsmgr": {"chroot": false, "maxproc": 1, "type": "unix", "wakeup": "1000?"}, "rewrite": {"chroot": false, "command": "trivial-rewrite", "type": "unix"}, "bounce": {"chroot": false, "maxproc": 0, "type": "unix"}, "defer": {"chroot": false, "command": "bounce", "maxproc": 0, "type": "unix"}, "trace": {"chroot": false, "command": "bounce", "maxproc": 0, "type": "unix"}, "smtp-unix": {"chroot": false, "command": "smtp", "service": "smtp", "type": "unix"}, "verify": {"chroot": false, "maxproc": 1, "type": "unix"}, "flush": {"chroot": false, "maxproc": 0, "private": false, "type": "unix", "wakeup": "1000?"}, "proxymap": {"chroot": false, "type": "unix"}, "proxywrite": {"chroot": false, "command": "proxymap", "maxproc": 1, "type": "unix"}, "relay": {"args": ["#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5"], "chroot": false, "command": "smtp", "type": "unix"}, "showq": {"chroot": false, "private": false, "type": "unix"}, "error": {"chroot": false, "type": "unix"}, "retry": {"chroot": false, "command": "error", "type": "unix"}, "discard": {"chroot": false, "type": "unix"}, "local": {"chroot": false, "type": "unix", "unpriv": false}, "virtual": {"chroot": false, "type": "unix", "unpriv": false}, "lmtp": {"chroot": false, "type": "unix"}, "anvil": {"chroot": false, "maxproc": 1, "type": "unix"}, "scache": {"chroot": false, "maxproc": 1, "type": "unix"}, "maildrop": {"argv": "/usr/local/bin/maildrop", "chroot": false, "command": "pipe", "enable": false, "extras": "-d ${recipient}", "flags": "DRhu", "type": "unix", "unpriv": false, "user": "vmail"}, "cyrus": {"argv": "/cyrus/bin/deliver", "chroot": false, "command": "pipe", "enable": false, "extras": "-e -r ${sender} -m ${extension} ${user}", "type": "unix", "unpriv": false, "user": "cyrus"}, "old-cyrus": {"argv": "/cyrus/bin/deliver", "chroot": false, "command": "pipe", "enable": false, "extras": "-e -m ${extension} ${user}", "flags": "R", "type": "unix", "unpriv": false, "user": "cyrus"}, "uucp": {"argv": "uux", "chroot": false, "command": "pipe", "enable": false, "extras": "-r -n -z -a$sender - $nexthop!rmail ($recipient)", "flags": "Fqhu", "type": "unix", "unpriv": false, "user": "uucp"}, "ifmail": {"argv": "/usr/lib/ifmail/ifmail", "chroot": false, "command": "pipe", "enable": false, "extras": "-r $nexthop ($recipient)", "flags": "F", "type": "unix", "unpriv": false, "user": "ftn"}, "bsmtp": {"argv": "/usr/local/sbin/bsmtp", "chroot": false, "command": "pipe", "enable": false, "extras": "-f $sender $nexthop $recipient", "flags": "Fq.", "type": "unix", "unpriv": false, "user": "bsmtp"}, "scalemail-backend": {"argv": "/usr/lib/scalemail/bin/scalemail-store", "chroot": false, "command": "pipe", "enable": false, "extras": "${nexthop} ${user} ${extension}", "flags": "R", "maxproc": 2, "type": "unix", "unpriv": false, "user": "scalemail"}, "mailman": {"argv": "/usr/lib/mailman/bin/postfix-to-mailman.py", "chroot": false, "command": "pipe", "enable": false, "extras": "${nexthop} ${user}", "flags": "FR", "type": "unix", "unpriv": false, "user": "list"}}, "order": ["smtp", "smtp-postscreen", "smtpd", "dnsblog", "tlsproxy", "submission", "smtps", "628", "pickup", "cleanup", "qmgr", "qmgr-oqmgr", "tlsmgr", "rewrite", "bounce", "defer", "trace", "verify", "flush", "proxymap", "proxywrite", "smtp-unix", "relay", "showq", "error", "retry", "discard", "local", "virtual", "lmtp", "anvil", "scache"]}


# manage various mappings


[DEBUG   ] Results of YAML rendering: 
OrderedDict([('include', ['postfix']), ('postfix-config-file-directory-config-path', OrderedDict([('file.directory', [OrderedDict([('name', '/etc/postfix')]), OrderedDict([('user', 'root')]), OrderedDict([('group', 'root')]), OrderedDict([('dir_mode', '0755')]), OrderedDict([('file_mode', '0644')]), OrderedDict([('makedirs', True)])])])), ('postfix-config-file-managed-main.cf', OrderedDict([('file.managed', [OrderedDict([('name', '/etc/postfix/main.cf')]), OrderedDict([('source', 'salt://postfix/files/main.cf')]), OrderedDict([('user', 'root')]), OrderedDict([('group', 'root')]), OrderedDict([('mode', '0644')]), OrderedDict([('require', [OrderedDict([('pkg', 'postfix-init-pkg-installed-postfix')])])]), OrderedDict([('watch_in', [OrderedDict([('service', 'postfix-init-service-running-postfix')])])]), OrderedDict([('template', 'jinja')]), OrderedDict([('context', OrderedDict([('postfix', OrderedDict([('aliases_file', '/etc/aliases'), ('config_path', '/etc/postfix'), ('package', 'postfix'), ('postsrsd_pkg', 'postsrsd'), ('postgrey_pkg', 'postgrey'), ('root_grp', 'root'), ('setgid_group', 'maildrop'), ('daemon_directory', '/usr/lib/postfix/bin'), ('service', 'postfix'), ('xbin_prefix', '/usr'), ('dovecot_deliver', '/usr/lib/dovecot/deliver'), ('default_database_type', 'hash')]))]))])])])), ('postfix-config-file-managed-master.cf', OrderedDict([('file.managed', [OrderedDict([('name', '/etc/postfix/master.cf')]), OrderedDict([('source', 'salt://postfix/files/master.cf')]), OrderedDict([('user', 'root')]), OrderedDict([('group', 'root')]), OrderedDict([('mode', '0644')]), OrderedDict([('require', [OrderedDict([('pkg', 'postfix-init-pkg-installed-postfix')])])]), OrderedDict([('watch_in', [OrderedDict([('service', 'postfix-init-service-running-postfix')])])]), OrderedDict([('template', 'jinja')]), OrderedDict([('context', OrderedDict([('postfix', OrderedDict([('aliases_file', '/etc/aliases'), ('config_path', '/etc/postfix'), ('package', 'postfix'), ('postsrsd_pkg', 'postsrsd'), ('postgrey_pkg', 'postgrey'), ('root_grp', 'root'), ('setgid_group', 'maildrop'), ('daemon_directory', '/usr/lib/postfix/bin'), ('service', 'postfix'), ('xbin_prefix', '/usr'), ('dovecot_deliver', '/usr/lib/dovecot/deliver'), ('default_database_type', 'hash')])), ('postfix_master_services', OrderedDict([('defaults', OrderedDict([('smtp', OrderedDict([('chroot', False), ('command', 'smtpd'), ('private', False), ('type', 'inet')])), ('smtp-postscreen', OrderedDict([('chroot', False), ('command', 'postscreen'), ('enable', False), ('maxproc', 1), ('private', False), ('service', 'smtp'), ('type', 'inet')])), ('smtpd', OrderedDict([('chroot', False), ('enable', False), ('type', 'pass')])), ('dnsblog', OrderedDict([('chroot', False), ('enable', False), ('maxproc', 0), ('type', 'unix')])), ('tlsproxy', OrderedDict([('chroot', False), ('enable', False), ('maxproc', 0), ('type', 'unix')])), ('submission', OrderedDict([('args', ['-o syslog_name=postfix/submission', '-o smtpd_tls_security_level=encrypt', '-o smtpd_sasl_auth_enable=yes', '-o smtpd_reject_unlisted_recipient=no', '-o smtpd_client_restrictions=$mua_client_restrictions', '-o smtpd_helo_restrictions=$mua_helo_restrictions', '-o smtpd_sender_restrictions=$mua_sender_restrictions', '-o smtpd_recipient_restrictions=permit_sasl_authenticated,reject', '-o milter_macro_daemon_name=ORIGINATING']), ('chroot', False), ('command', 'smtpd'), ('enable', False), ('private', False), ('type', 'inet')])), ('smtps', OrderedDict([('args', ['-o syslog_name=postfix/smtps', '-o smtpd_tls_wrappermode=yes', '-o smtpd_sasl_auth_enable=yes', '-o smtpd_reject_unlisted_recipient=no', '-o smtpd_client_restrictions=$mua_client_restrictions', '-o smtpd_helo_restrictions=$mua_helo_restrictions', '-o smtpd_sender_restrictions=$mua_sender_restrictions', '-o smtpd_recipient_restrictions=permit_sasl_authenticated,reject', '-o milter_macro_daemon_name=ORIGINATING']), ('chroot', False), ('command', 'smtpd'), ('enable', False), ('private', False), ('type', 'inet')])), ('628', OrderedDict([('chroot', False), ('command', 'qmqpd'), ('enable', False), ('private', False), ('type', 'inet')])), ('pickup', OrderedDict([('chroot', False), ('maxproc', 1), ('private', False), ('type', 'unix'), ('wakeup', 60)])), ('cleanup', OrderedDict([('chroot', False), ('maxproc', 0), ('private', False), ('type', 'unix')])), ('qmgr', OrderedDict([('chroot', False), ('maxproc', 1), ('private', False), ('type', 'unix'), ('wakeup', 300)])), ('qmgr-oqmgr', OrderedDict([('chroot', False), ('command', 'oqmgr'), ('enable', False), ('maxproc', 1), ('private', False), ('service', 'qmgr'), ('type', 'unix'), ('wakeup', 300)])), ('tlsmgr', OrderedDict([('chroot', False), ('maxproc', 1), ('type', 'unix'), ('wakeup', '1000?')])), ('rewrite', OrderedDict([('chroot', False), ('command', 'trivial-rewrite'), ('type', 'unix')])), ('bounce', OrderedDict([('chroot', False), ('maxproc', 0), ('type', 'unix')])), ('defer', OrderedDict([('chroot', False), ('command', 'bounce'), ('maxproc', 0), ('type', 'unix')])), ('trace', OrderedDict([('chroot', False), ('command', 'bounce'), ('maxproc', 0), ('type', 'unix')])), ('smtp-unix', OrderedDict([('chroot', False), ('command', 'smtp'), ('service', 'smtp'), ('type', 'unix')])), ('verify', OrderedDict([('chroot', False), ('maxproc', 1), ('type', 'unix')])), ('flush', OrderedDict([('chroot', False), ('maxproc', 0), ('private', False), ('type', 'unix'), ('wakeup', '1000?')])), ('proxymap', OrderedDict([('chroot', False), ('type', 'unix')])), ('proxywrite', OrderedDict([('chroot', False), ('command', 'proxymap'), ('maxproc', 1), ('type', 'unix')])), ('relay', OrderedDict([('args', ['#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5']), ('chroot', False), ('command', 'smtp'), ('type', 'unix')])), ('showq', OrderedDict([('chroot', False), ('private', False), ('type', 'unix')])), ('error', OrderedDict([('chroot', False), ('type', 'unix')])), ('retry', OrderedDict([('chroot', False), ('command', 'error'), ('type', 'unix')])), ('discard', OrderedDict([('chroot', False), ('type', 'unix')])), ('local', OrderedDict([('chroot', False), ('type', 'unix'), ('unpriv', False)])), ('virtual', OrderedDict([('chroot', False), ('type', 'unix'), ('unpriv', False)])), ('lmtp', OrderedDict([('chroot', False), ('type', 'unix')])), ('anvil', OrderedDict([('chroot', False), ('maxproc', 1), ('type', 'unix')])), ('scache', OrderedDict([('chroot', False), ('maxproc', 1), ('type', 'unix')])), ('maildrop', OrderedDict([('argv', '/usr/local/bin/maildrop'), ('chroot', False), ('command', 'pipe'), ('enable', False), ('extras', '-d ${recipient}'), ('flags', 'DRhu'), ('type', 'unix'), ('unpriv', False), ('user', 'vmail')])), ('cyrus', OrderedDict([('argv', '/cyrus/bin/deliver'), ('chroot', False), ('command', 'pipe'), ('enable', False), ('extras', '-e -r ${sender} -m ${extension} ${user}'), ('type', 'unix'), ('unpriv', False), ('user', 'cyrus')])), ('old-cyrus', OrderedDict([('argv', '/cyrus/bin/deliver'), ('chroot', False), ('command', 'pipe'), ('enable', False), ('extras', '-e -m ${extension} ${user}'), ('flags', 'R'), ('type', 'unix'), ('unpriv', False), ('user', 'cyrus')])), ('uucp', OrderedDict([('argv', 'uux'), ('chroot', False), ('command', 'pipe'), ('enable', False), ('extras', '-r -n -z -a$sender - $nexthop!rmail ($recipient)'), ('flags', 'Fqhu'), ('type', 'unix'), ('unpriv', False), ('user', 'uucp')])), ('ifmail', OrderedDict([('argv', '/usr/lib/ifmail/ifmail'), ('chroot', False), ('command', 'pipe'), ('enable', False), ('extras', '-r $nexthop ($recipient)'), ('flags', 'F'), ('type', 'unix'), ('unpriv', False), ('user', 'ftn')])), ('bsmtp', OrderedDict([('argv', '/usr/local/sbin/bsmtp'), ('chroot', False), ('command', 'pipe'), ('enable', False), ('extras', '-f $sender $nexthop $recipient'), ('flags', 'Fq.'), ('type', 'unix'), ('unpriv', False), ('user', 'bsmtp')])), ('scalemail-backend', OrderedDict([('argv', '/usr/lib/scalemail/bin/scalemail-store'), ('chroot', False), ('command', 'pipe'), ('enable', False), ('extras', '${nexthop} ${user} ${extension}'), ('flags', 'R'), ('maxproc', 2), ('type', 'unix'), ('unpriv', False), ('user', 'scalemail')])), ('mailman', OrderedDict([('argv', '/usr/lib/mailman/bin/postfix-to-mailman.py'), ('chroot', False), ('command', 'pipe'), ('enable', False), ('extras', '${nexthop} ${user}'), ('flags', 'FR'), ('type', 'unix'), ('unpriv', False), ('user', 'list')]))])), ('order', ['smtp', 'smtp-postscreen', 'smtpd', 'dnsblog', 'tlsproxy', 'submission', 'smtps', '628', 'pickup', 'cleanup', 'qmgr', 'qmgr-oqmgr', 'tlsmgr', 'rewrite', 'bounce', 'defer', 'trace', 'verify', 'flush', 'proxymap', 'proxywrite', 'smtp-unix', 'relay', 'showq', 'error', 'retry', 'discard', 'local', 'virtual', 'lmtp', 'anvil', 'scache'])]))]))])])]))])
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/production/postfix/config.sls' using 'yaml' renderer: 0.04537057876586914
[DEBUG   ] Could not find file 'salt://postfix.sls' in saltenv 'production'
[DEBUG   ] In saltenv 'production', looking at rel_path 'postfix/init.sls' to resolve 'salt://postfix/init.sls'
[DEBUG   ] In saltenv 'production', ** considering ** path '/var/cache/salt/minion/files/production/postfix/init.sls' to resolve 'salt://postfix/init.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/production/postfix/init.sls
[DEBUG   ] Jinja search path: ['/var/cache/salt/minion/files/production']
[DEBUG   ] In saltenv 'production', looking at rel_path 'postfix/map.jinja' to resolve 'salt://postfix/map.jinja'
[DEBUG   ] In saltenv 'production', ** considering ** path '/var/cache/salt/minion/files/production/postfix/map.jinja' to resolve 'salt://postfix/map.jinja'
[DEBUG   ] In saltenv 'production', looking at rel_path 'postfix/defaults.yaml' to resolve 'salt://postfix/defaults.yaml'
[DEBUG   ] In saltenv 'production', ** considering ** path '/var/cache/salt/minion/files/production/postfix/defaults.yaml' to resolve 'salt://postfix/defaults.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'postfix/defaults.yaml': 0.003597736358642578
[DEBUG   ] In saltenv 'production', looking at rel_path 'postfix/osfamilymap.yaml' to resolve 'salt://postfix/osfamilymap.yaml'
[DEBUG   ] In saltenv 'production', ** considering ** path '/var/cache/salt/minion/files/production/postfix/osfamilymap.yaml' to resolve 'salt://postfix/osfamilymap.yaml'
[PROFILE ] Time (in seconds) to render import_yaml 'postfix/osfamilymap.yaml': 0.00620722770690918
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/production/postfix/init.sls' using 'jinja' renderer: 0.0281069278717041
[DEBUG   ] Rendered data from file: /var/cache/salt/minion/files/production/postfix/init.sls:

# The existence of this file prevents the system to
# overwrite files from salt when installing.
postfix-init-file-managed-postfix.configured:
  file.managed:
    - name: /var/adm/postfix.configured
    - contents: ''
    - mode: '0644'
    - user: 'root'
    - group: 'root'
    - require_in:
      - pkg: postfix-init-pkg-installed-postfix

postfix-init-pkg-installed-postfix:
  pkg.installed:
    - name: postfix
    - watch_in:
      - service: postfix-init-service-running-postfix

postfix-init-service-running-postfix:
  service.running:
    - name: postfix
    - enable: True
    - reload: True
    - require:
      - pkg: postfix-init-pkg-installed-postfix
    - watch:
      - pkg: postfix-init-pkg-installed-postfix
# Restart postfix if the package was changed.
# This also provides an ID to be used in a watch_in statement.
postfix-init-service-running-postfix-restart:
  service.running:
    - name: postfix
    - watch:
      - pkg: postfix-init-pkg-installed-postfix

# manage /etc/aliases if data found in pillar


[DEBUG   ] Results of YAML rendering: 
OrderedDict([('postfix-init-file-managed-postfix.configured', OrderedDict([('file.managed', [OrderedDict([('name', '/var/adm/postfix.configured')]), OrderedDict([('contents', '')]), OrderedDict([('mode', '0644')]), OrderedDict([('user', 'root')]), OrderedDict([('group', 'root')]), OrderedDict([('require_in', [OrderedDict([('pkg', 'postfix-init-pkg-installed-postfix')])])])])])), ('postfix-init-pkg-installed-postfix', OrderedDict([('pkg.installed', [OrderedDict([('name', 'postfix')]), OrderedDict([('watch_in', [OrderedDict([('service', 'postfix-init-service-running-postfix')])])])])])), ('postfix-init-service-running-postfix', OrderedDict([('service.running', [OrderedDict([('name', 'postfix')]), OrderedDict([('enable', True)]), OrderedDict([('reload', True)]), OrderedDict([('require', [OrderedDict([('pkg', 'postfix-init-pkg-installed-postfix')])])]), OrderedDict([('watch', [OrderedDict([('pkg', 'postfix-init-pkg-installed-postfix')])])])])])), ('postfix-init-service-running-postfix-restart', OrderedDict([('service.running', [OrderedDict([('name', 'postfix')]), OrderedDict([('watch', [OrderedDict([('pkg', 'postfix-init-pkg-installed-postfix')])])])])]))])
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/production/postfix/init.sls' using 'yaml' renderer: 0.00554656982421875
[DEBUG   ] LazyLoaded config.option
[DEBUG   ] LazyLoaded file.managed
[INFO    ] Running state [/var/adm/postfix.configured] at time 18:00:15.476483
[INFO    ] Executing state file.managed for [/var/adm/postfix.configured]
[DEBUG   ] LazyLoaded file.user_to_uid
[DEBUG   ] LazyLoaded cp.cache_file
[DEBUG   ] Using importlib_metadata to load entry points
[DEBUG   ] LazyLoaded roots.envs
[DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
[INFO    ] File /var/adm/postfix.configured is in the correct state
[INFO    ] Completed state [/var/adm/postfix.configured] at time 18:00:15.533931 (duration_in_ms=57.451)
[DEBUG   ] LazyLoaded pkg.install
[DEBUG   ] LazyLoaded pkg.installed
[DEBUG   ] LazyLoaded path.which
[DEBUG   ] Override  __salt__: <module 'salt.loaded.int.module.dracr' from '/usr/lib/python3.6/site-packages/salt/modules/dracr.py'>
[DEBUG   ] Reading configuration from /etc/salt/minion
[DEBUG   ] Including configuration from '/etc/salt/minion.d/local-lysergic.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/local-lysergic.conf
[DEBUG   ] Including configuration from '/etc/salt/minion.d/local.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/local.conf
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: bd5de19d49b1
[DEBUG   ] Using importlib_metadata to load entry points
[DEBUG   ] Could not LazyLoad idem.hub: 'idem' __virtual__ returned False: No module named 'pop'
[DEBUG   ] Override  __salt__: <module 'salt.loaded.int.module.kubeadm' from '/usr/lib/python3.6/site-packages/salt/modules/kubeadm.py'>
[DEBUG   ] Override  __salt__: <module 'salt.loaded.int.module.udev' from '/usr/lib/python3.6/site-packages/salt/modules/udev.py'>
[DEBUG   ] Override  __pillar__: <module 'salt.loaded.int.module.virtualenv_mod' from '/usr/lib/python3.6/site-packages/salt/modules/virtualenv_mod.py'>
[DEBUG   ] DSC: Only available on Windows systems
[DEBUG   ] Module PSGet: Only available on Windows systems
[DEBUG   ] Could not LazyLoad pkg.ex_mod_init: 'pkg.ex_mod_init' is not available.
[INFO    ] Running state [postfix] at time 18:00:16.699093
[INFO    ] Executing state pkg.installed for [postfix]
[DEBUG   ] Calling Zypper: zypper --non-interactive refresh
[INFO    ] Executing command zypper in directory '/root'
[INFO    ] Executing command rpm in directory '/root'
[INFO    ] All specified packages are already installed
[INFO    ] Completed state [postfix] at time 18:00:20.414968 (duration_in_ms=3715.875)
[DEBUG   ] LazyLoaded service.running
[INFO    ] Running state [/etc/postfix/main.cf] at time 18:00:20.419352
[INFO    ] Executing state file.managed for [/etc/postfix/main.cf]
[DEBUG   ] In saltenv 'production', looking at rel_path 'postfix/files/main.cf' to resolve 'salt://postfix/files/main.cf'
[DEBUG   ] In saltenv 'production', ** considering ** path '/var/cache/salt/minion/files/production/postfix/files/main.cf' to resolve 'salt://postfix/files/main.cf'
[DEBUG   ] Jinja search path: ['/var/cache/salt/minion/files/production']
[DEBUG   ] Using importlib_metadata to load entry points
[DEBUG   ] LazyLoaded roots.envs
[DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
[INFO    ] File /etc/postfix/main.cf is in the correct state
[INFO    ] Completed state [/etc/postfix/main.cf] at time 18:00:20.583066 (duration_in_ms=163.714)
[INFO    ] Running state [/etc/postfix/master.cf] at time 18:00:20.583599
[INFO    ] Executing state file.managed for [/etc/postfix/master.cf]
[DEBUG   ] In saltenv 'production', looking at rel_path 'postfix/files/master.cf' to resolve 'salt://postfix/files/master.cf'
[DEBUG   ] In saltenv 'production', ** considering ** path '/var/cache/salt/minion/files/production/postfix/files/master.cf' to resolve 'salt://postfix/files/master.cf'
[DEBUG   ] Jinja search path: ['/var/cache/salt/minion/files/production']
[INFO    ] File /etc/postfix/master.cf is in the correct state
[INFO    ] Completed state [/etc/postfix/master.cf] at time 18:00:20.718426 (duration_in_ms=134.827)
[INFO    ] Running state [postfix] at time 18:00:20.719595
[INFO    ] Executing state service.running for [postfix]
[INFO    ] Running in OFFLINE mode. Nothing to do
[INFO    ] Completed state [postfix] at time 18:00:20.722854 (duration_in_ms=3.258)
[INFO    ] Running state [postfix] at time 18:00:20.723511
[INFO    ] Executing state service.running for [postfix]
[INFO    ] Running in OFFLINE mode. Nothing to do
[INFO    ] Completed state [postfix] at time 18:00:20.725235 (duration_in_ms=1.724)
[INFO    ] Running state [/etc/postfix] at time 18:00:20.725537
[INFO    ] Executing state file.directory for [/etc/postfix]
[INFO    ] The directory /etc/postfix is in the correct state
[INFO    ] Completed state [/etc/postfix] at time 18:00:20.727938 (duration_in_ms=2.401)
[DEBUG   ] File /var/cache/salt/minion/accumulator/140174700218688 does not exist, no need to cleanup
[DEBUG   ] LazyLoaded state.check_result
[DEBUG   ] LazyLoaded highstate.output
local:
----------
          ID: postfix-init-file-managed-postfix.configured
    Function: file.managed
        Name: /var/adm/postfix.configured
      Result: True
     Comment: File /var/adm/postfix.configured is in the correct state
     Started: 18:00:15.476480
    Duration: 57.451 ms
     Changes:   
----------
          ID: postfix-init-pkg-installed-postfix
    Function: pkg.installed
        Name: postfix
      Result: True
     Comment: All specified packages are already installed
     Started: 18:00:16.699093
    Duration: 3715.875 ms
     Changes:   
----------
          ID: postfix-config-file-managed-main.cf
    Function: file.managed
        Name: /etc/postfix/main.cf
      Result: True
     Comment: File /etc/postfix/main.cf is in the correct state
     Started: 18:00:20.419352
    Duration: 163.714 ms
     Changes:   
----------
          ID: postfix-config-file-managed-master.cf
    Function: file.managed
        Name: /etc/postfix/master.cf
      Result: True
     Comment: File /etc/postfix/master.cf is in the correct state
     Started: 18:00:20.583599
    Duration: 134.827 ms
     Changes:   
----------
          ID: postfix-init-service-running-postfix
    Function: service.running
        Name: postfix
      Result: True
     Comment: Running in OFFLINE mode. Nothing to do
     Started: 18:00:20.719596
    Duration: 3.258 ms
     Changes:   
----------
          ID: postfix-init-service-running-postfix-restart
    Function: service.running
        Name: postfix
      Result: True
     Comment: Running in OFFLINE mode. Nothing to do
     Started: 18:00:20.723511
    Duration: 1.724 ms
     Changes:   
----------
          ID: postfix-config-file-directory-config-path
    Function: file.directory
        Name: /etc/postfix
      Result: True
     Comment: The directory /etc/postfix is in the correct state
     Started: 18:00:20.725537
    Duration: 2.401 ms
     Changes:   

Summary for local
------------
Succeeded: 7
Failed:    0
------------
Total states run:     7
Total run time:   4.079 s
```

</details>


### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [x] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


